### PR TITLE
refactor: encapsulate Asn1Integer.value property

### DIFF
--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Angle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Angle.java
@@ -34,6 +34,6 @@ public class Angle extends Asn1Integer {
   @JsonCreator
   public Angle(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Day.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Day.java
@@ -34,6 +34,6 @@ public class Day extends Asn1Integer {
   @JsonCreator
   public Day(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/DegreesLat.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/DegreesLat.java
@@ -34,6 +34,6 @@ public class DegreesLat extends Asn1Integer {
   @JsonCreator
   public DegreesLat(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/DegreesLong.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/DegreesLong.java
@@ -34,6 +34,6 @@ public class DegreesLong extends Asn1Integer {
   @JsonCreator
   public DegreesLong(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Elevation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Elevation.java
@@ -34,6 +34,6 @@ public class Elevation extends Asn1Integer {
   @JsonCreator
   public Elevation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Hour.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Hour.java
@@ -34,6 +34,6 @@ public class Hour extends Asn1Integer {
   @JsonCreator
   public Hour(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/LatitudeDMS.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/LatitudeDMS.java
@@ -34,6 +34,6 @@ public class LatitudeDMS extends Asn1Integer {
   @JsonCreator
   public LatitudeDMS(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/LongitudeDMS.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/LongitudeDMS.java
@@ -34,6 +34,6 @@ public class LongitudeDMS extends Asn1Integer {
   @JsonCreator
   public LongitudeDMS(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/MaxTimetoChange.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/MaxTimetoChange.java
@@ -34,6 +34,6 @@ public class MaxTimetoChange extends Asn1Integer {
   @JsonCreator
   public MaxTimetoChange(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/MinTimetoChange.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/MinTimetoChange.java
@@ -34,6 +34,6 @@ public class MinTimetoChange extends Asn1Integer {
   @JsonCreator
   public MinTimetoChange(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Minute.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Minute.java
@@ -34,6 +34,6 @@ public class Minute extends Asn1Integer {
   @JsonCreator
   public Minute(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/MinutesAngle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/MinutesAngle.java
@@ -34,6 +34,6 @@ public class MinutesAngle extends Asn1Integer {
   @JsonCreator
   public MinutesAngle(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Month.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Month.java
@@ -34,6 +34,6 @@ public class Month extends Asn1Integer {
   @JsonCreator
   public Month(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/MsgCount.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/MsgCount.java
@@ -34,6 +34,6 @@ public class MsgCount extends Asn1Integer {
   @JsonCreator
   public MsgCount(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Second.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Second.java
@@ -34,6 +34,6 @@ public class Second extends Asn1Integer {
   @JsonCreator
   public Second(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/SecondsAngle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/SecondsAngle.java
@@ -34,6 +34,6 @@ public class SecondsAngle extends Asn1Integer {
   @JsonCreator
   public SecondsAngle(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/TenthSecond.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/TenthSecond.java
@@ -34,6 +34,6 @@ public class TenthSecond extends Asn1Integer {
   @JsonCreator
   public TenthSecond(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/TimeRemaining.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/TimeRemaining.java
@@ -34,6 +34,6 @@ public class TimeRemaining extends Asn1Integer {
   @JsonCreator
   public TimeRemaining(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Year.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpB/Year.java
@@ -34,6 +34,6 @@ public class Year extends Asn1Integer {
   @JsonCreator
   public Year(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpC/AltitudeValue.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/AddGrpC/AltitudeValue.java
@@ -34,6 +34,6 @@ public class AltitudeValue extends Asn1Integer {
   @JsonCreator
   public AltitudeValue(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/ObstacleDirection.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/ObstacleDirection.java
@@ -34,6 +34,6 @@ public class ObstacleDirection extends Angle {
   @JsonCreator
   public ObstacleDirection(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/PartII_Id.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/PartII_Id.java
@@ -34,6 +34,6 @@ public class PartII_Id extends Asn1Integer {
   @JsonCreator
   public PartII_Id(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/SpeedProfileMeasurement.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/SpeedProfileMeasurement.java
@@ -34,6 +34,6 @@ public class SpeedProfileMeasurement extends GrossSpeed {
   @JsonCreator
   public SpeedProfileMeasurement(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/TrailerMass.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/TrailerMass.java
@@ -34,6 +34,6 @@ public class TrailerMass extends Asn1Integer {
   @JsonCreator
   public TrailerMass(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/VehicleData.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/VehicleData.java
@@ -87,7 +87,7 @@ public class VehicleData extends Asn1Sequence {
     @JsonCreator
     public LeanAngleInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/VertOffset_B07.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/VertOffset_B07.java
@@ -34,6 +34,6 @@ public class VertOffset_B07 extends Asn1Integer {
   @JsonCreator
   public VertOffset_B07(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Acceleration.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Acceleration.java
@@ -34,6 +34,6 @@ public class Acceleration extends Asn1Integer {
   @JsonCreator
   public Acceleration(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/AmbientAirPressure.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/AmbientAirPressure.java
@@ -34,6 +34,6 @@ public class AmbientAirPressure extends Asn1Integer {
   @JsonCreator
   public AmbientAirPressure(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/AmbientAirTemperature.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/AmbientAirTemperature.java
@@ -34,6 +34,6 @@ public class AmbientAirTemperature extends Asn1Integer {
   @JsonCreator
   public AmbientAirTemperature(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Angle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Angle.java
@@ -34,6 +34,6 @@ public class Angle extends Asn1Integer {
   @JsonCreator
   public Angle(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/ApproachID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/ApproachID.java
@@ -34,6 +34,6 @@ public class ApproachID extends Asn1Integer {
   @JsonCreator
   public ApproachID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Axles.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Axles.java
@@ -61,7 +61,7 @@ public class Axles extends Asn1Sequence {
     @JsonCreator
     public TotalAxlesInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -73,7 +73,7 @@ public class Axles extends Asn1Sequence {
     @JsonCreator
     public FrontAxlesInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -85,7 +85,7 @@ public class Axles extends Asn1Sequence {
     @JsonCreator
     public RearAxlesInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/BasicVehicleClass.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/BasicVehicleClass.java
@@ -41,7 +41,7 @@ public class BasicVehicleClass extends Asn1Integer {
   @JsonCreator
   public BasicVehicleClass(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -115,7 +115,7 @@ public class BasicVehicleClass extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<BasicVehicleClass> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/BumperHeight.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/BumperHeight.java
@@ -34,6 +34,6 @@ public class BumperHeight extends Asn1Integer {
   @JsonCreator
   public BumperHeight(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/CoarseHeading.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/CoarseHeading.java
@@ -34,6 +34,6 @@ public class CoarseHeading extends Asn1Integer {
   @JsonCreator
   public CoarseHeading(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/CoefficientOfFriction.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/CoefficientOfFriction.java
@@ -34,6 +34,6 @@ public class CoefficientOfFriction extends Asn1Integer {
   @JsonCreator
   public CoefficientOfFriction(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Confidence.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Confidence.java
@@ -34,6 +34,6 @@ public class Confidence extends Asn1Integer {
   @JsonCreator
   public Confidence(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Count.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Count.java
@@ -34,6 +34,6 @@ public class Count extends Asn1Integer {
   @JsonCreator
   public Count(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DDay.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DDay.java
@@ -34,6 +34,6 @@ public class DDay extends Asn1Integer {
   @JsonCreator
   public DDay(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DHour.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DHour.java
@@ -34,6 +34,6 @@ public class DHour extends Asn1Integer {
   @JsonCreator
   public DHour(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DMinute.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DMinute.java
@@ -34,6 +34,6 @@ public class DMinute extends Asn1Integer {
   @JsonCreator
   public DMinute(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DMonth.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DMonth.java
@@ -34,6 +34,6 @@ public class DMonth extends Asn1Integer {
   @JsonCreator
   public DMonth(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DOffset.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DOffset.java
@@ -34,6 +34,6 @@ public class DOffset extends Asn1Integer {
   @JsonCreator
   public DOffset(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DSecond.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DSecond.java
@@ -34,6 +34,6 @@ public class DSecond extends Asn1Integer {
   @JsonCreator
   public DSecond(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DYear.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DYear.java
@@ -34,6 +34,6 @@ public class DYear extends Asn1Integer {
   @JsonCreator
   public DYear(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DeltaAngle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DeltaAngle.java
@@ -34,6 +34,6 @@ public class DeltaAngle extends Asn1Integer {
   @JsonCreator
   public DeltaAngle(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DrivenLineOffsetLg.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DrivenLineOffsetLg.java
@@ -34,6 +34,6 @@ public class DrivenLineOffsetLg extends Asn1Integer {
   @JsonCreator
   public DrivenLineOffsetLg(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DrivenLineOffsetSm.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/DrivenLineOffsetSm.java
@@ -34,6 +34,6 @@ public class DrivenLineOffsetSm extends Asn1Integer {
   @JsonCreator
   public DrivenLineOffsetSm(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Duration.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Duration.java
@@ -34,6 +34,6 @@ public class Duration extends Asn1Integer {
   @JsonCreator
   public Duration(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Elevation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Elevation.java
@@ -34,6 +34,6 @@ public class Elevation extends Asn1Integer {
   @JsonCreator
   public Elevation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/FuelType.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/FuelType.java
@@ -41,7 +41,7 @@ public class FuelType extends Asn1Integer {
   @JsonCreator
   public FuelType(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -69,7 +69,7 @@ public class FuelType extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<FuelType> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/GrossSpeed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/GrossSpeed.java
@@ -34,6 +34,6 @@ public class GrossSpeed extends Asn1Integer {
   @JsonCreator
   public GrossSpeed(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Heading.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Heading.java
@@ -34,6 +34,6 @@ public class Heading extends Asn1Integer {
   @JsonCreator
   public Heading(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/IntersectionID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/IntersectionID.java
@@ -34,6 +34,6 @@ public class IntersectionID extends Asn1Integer {
   @JsonCreator
   public IntersectionID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Iso3833VehicleType.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Iso3833VehicleType.java
@@ -34,6 +34,6 @@ public class Iso3833VehicleType extends Asn1Integer {
   @JsonCreator
   public Iso3833VehicleType(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/LaneConnectionID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/LaneConnectionID.java
@@ -34,6 +34,6 @@ public class LaneConnectionID extends Asn1Integer {
   @JsonCreator
   public LaneConnectionID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/LaneID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/LaneID.java
@@ -34,6 +34,6 @@ public class LaneID extends Asn1Integer {
   @JsonCreator
   public LaneID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/LaneWidth.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/LaneWidth.java
@@ -34,6 +34,6 @@ public class LaneWidth extends Asn1Integer {
   @JsonCreator
   public LaneWidth(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Latitude.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Latitude.java
@@ -34,6 +34,6 @@ public class Latitude extends Asn1Integer {
   @JsonCreator
   public Latitude(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Longitude.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Longitude.java
@@ -34,6 +34,6 @@ public class Longitude extends Asn1Integer {
   @JsonCreator
   public Longitude(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/MeanVariation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/MeanVariation.java
@@ -34,6 +34,6 @@ public class MeanVariation extends Asn1Integer {
   @JsonCreator
   public MeanVariation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/MergeDivergeNodeAngle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/MergeDivergeNodeAngle.java
@@ -34,6 +34,6 @@ public class MergeDivergeNodeAngle extends Asn1Integer {
   @JsonCreator
   public MergeDivergeNodeAngle(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/MinuteOfTheYear.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/MinuteOfTheYear.java
@@ -34,6 +34,6 @@ public class MinuteOfTheYear extends Asn1Integer {
   @JsonCreator
   public MinuteOfTheYear(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/MsgCount.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/MsgCount.java
@@ -34,6 +34,6 @@ public class MsgCount extends Asn1Integer {
   @JsonCreator
   public MsgCount(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/ObstacleDistance.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/ObstacleDistance.java
@@ -34,6 +34,6 @@ public class ObstacleDistance extends Asn1Integer {
   @JsonCreator
   public ObstacleDistance(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/OffsetLL_B18.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/OffsetLL_B18.java
@@ -34,6 +34,6 @@ public class OffsetLL_B18 extends Asn1Integer {
   @JsonCreator
   public OffsetLL_B18(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B09.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B09.java
@@ -34,6 +34,6 @@ public class Offset_B09 extends Asn1Integer {
   @JsonCreator
   public Offset_B09(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B10.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B10.java
@@ -34,6 +34,6 @@ public class Offset_B10 extends Asn1Integer {
   @JsonCreator
   public Offset_B10(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B11.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B11.java
@@ -34,6 +34,6 @@ public class Offset_B11 extends Asn1Integer {
   @JsonCreator
   public Offset_B11(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B12.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B12.java
@@ -34,6 +34,6 @@ public class Offset_B12 extends Asn1Integer {
   @JsonCreator
   public Offset_B12(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B13.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B13.java
@@ -34,6 +34,6 @@ public class Offset_B13 extends Asn1Integer {
   @JsonCreator
   public Offset_B13(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B14.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B14.java
@@ -34,6 +34,6 @@ public class Offset_B14 extends Asn1Integer {
   @JsonCreator
   public Offset_B14(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B16.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Offset_B16.java
@@ -34,6 +34,6 @@ public class Offset_B16 extends Asn1Integer {
   @JsonCreator
   public Offset_B16(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RadiusOfCurvature.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RadiusOfCurvature.java
@@ -34,6 +34,6 @@ public class RadiusOfCurvature extends Asn1Integer {
   @JsonCreator
   public RadiusOfCurvature(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RegionId.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RegionId.java
@@ -41,7 +41,7 @@ public class RegionId extends Asn1Integer {
   @JsonCreator
   public RegionId(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -64,7 +64,7 @@ public class RegionId extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<RegionId> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RequestID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RequestID.java
@@ -34,6 +34,6 @@ public class RequestID extends Asn1Integer {
   @JsonCreator
   public RequestID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RestrictionClassID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RestrictionClassID.java
@@ -34,6 +34,6 @@ public class RestrictionClassID extends Asn1Integer {
   @JsonCreator
   public RestrictionClassID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RoadRegulatorID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RoadRegulatorID.java
@@ -34,6 +34,6 @@ public class RoadRegulatorID extends Asn1Integer {
   @JsonCreator
   public RoadRegulatorID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RoadSegmentID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RoadSegmentID.java
@@ -34,6 +34,6 @@ public class RoadSegmentID extends Asn1Integer {
   @JsonCreator
   public RoadSegmentID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RoadwayCrownAngle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/RoadwayCrownAngle.java
@@ -34,6 +34,6 @@ public class RoadwayCrownAngle extends Asn1Integer {
   @JsonCreator
   public RoadwayCrownAngle(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SSPindex.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SSPindex.java
@@ -34,6 +34,6 @@ public class SSPindex extends Asn1Integer {
   @JsonCreator
   public SSPindex(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Scale_B12.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Scale_B12.java
@@ -34,6 +34,6 @@ public class Scale_B12 extends Asn1Integer {
   @JsonCreator
   public Scale_B12(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SemiMajorAxisAccuracy.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SemiMajorAxisAccuracy.java
@@ -34,6 +34,6 @@ public class SemiMajorAxisAccuracy extends Asn1Integer {
   @JsonCreator
   public SemiMajorAxisAccuracy(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SemiMajorAxisOrientation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SemiMajorAxisOrientation.java
@@ -34,6 +34,6 @@ public class SemiMajorAxisOrientation extends Asn1Integer {
   @JsonCreator
   public SemiMajorAxisOrientation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SemiMinorAxisAccuracy.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SemiMinorAxisAccuracy.java
@@ -34,6 +34,6 @@ public class SemiMinorAxisAccuracy extends Asn1Integer {
   @JsonCreator
   public SemiMinorAxisAccuracy(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SignalGroupID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SignalGroupID.java
@@ -34,6 +34,6 @@ public class SignalGroupID extends Asn1Integer {
   @JsonCreator
   public SignalGroupID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Speed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Speed.java
@@ -34,6 +34,6 @@ public class Speed extends Asn1Integer {
   @JsonCreator
   public Speed(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/StationID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/StationID.java
@@ -34,6 +34,6 @@ public class StationID extends Asn1Integer {
   @JsonCreator
   public StationID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SteeringWheelAngle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/SteeringWheelAngle.java
@@ -34,6 +34,6 @@ public class SteeringWheelAngle extends Asn1Integer {
   @JsonCreator
   public SteeringWheelAngle(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/TimeOffset.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/TimeOffset.java
@@ -34,6 +34,6 @@ public class TimeOffset extends Asn1Integer {
   @JsonCreator
   public TimeOffset(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/TrailerWeight.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/TrailerWeight.java
@@ -34,6 +34,6 @@ public class TrailerWeight extends Asn1Integer {
   @JsonCreator
   public TrailerWeight(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VariationStdDev.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VariationStdDev.java
@@ -34,6 +34,6 @@ public class VariationStdDev extends Asn1Integer {
   @JsonCreator
   public VariationStdDev(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VehicleHeight.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VehicleHeight.java
@@ -34,6 +34,6 @@ public class VehicleHeight extends Asn1Integer {
   @JsonCreator
   public VehicleHeight(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VehicleLength.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VehicleLength.java
@@ -34,6 +34,6 @@ public class VehicleLength extends Asn1Integer {
   @JsonCreator
   public VehicleLength(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VehicleMass.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VehicleMass.java
@@ -34,6 +34,6 @@ public class VehicleMass extends Asn1Integer {
   @JsonCreator
   public VehicleMass(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VehicleWidth.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VehicleWidth.java
@@ -34,6 +34,6 @@ public class VehicleWidth extends Asn1Integer {
   @JsonCreator
   public VehicleWidth(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Velocity.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/Velocity.java
@@ -34,6 +34,6 @@ public class Velocity extends Asn1Integer {
   @JsonCreator
   public Velocity(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VertOffset_B08.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VertOffset_B08.java
@@ -34,6 +34,6 @@ public class VertOffset_B08 extends Asn1Integer {
   @JsonCreator
   public VertOffset_B08(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VertOffset_B09.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VertOffset_B09.java
@@ -34,6 +34,6 @@ public class VertOffset_B09 extends Asn1Integer {
   @JsonCreator
   public VertOffset_B09(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VertOffset_B10.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VertOffset_B10.java
@@ -34,6 +34,6 @@ public class VertOffset_B10 extends Asn1Integer {
   @JsonCreator
   public VertOffset_B10(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VertOffset_B11.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VertOffset_B11.java
@@ -34,6 +34,6 @@ public class VertOffset_B11 extends Asn1Integer {
   @JsonCreator
   public VertOffset_B11(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VertOffset_B12.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VertOffset_B12.java
@@ -34,6 +34,6 @@ public class VertOffset_B12 extends Asn1Integer {
   @JsonCreator
   public VertOffset_B12(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VerticalAcceleration.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VerticalAcceleration.java
@@ -34,6 +34,6 @@ public class VerticalAcceleration extends Asn1Integer {
   @JsonCreator
   public VerticalAcceleration(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/WiperRate.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/WiperRate.java
@@ -34,6 +34,6 @@ public class WiperRate extends Asn1Integer {
   @JsonCreator
   public WiperRate(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/YawRate.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/YawRate.java
@@ -34,6 +34,6 @@ public class YawRate extends Asn1Integer {
   @JsonCreator
   public YawRate(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/AcceleratorPedalPosition.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/AcceleratorPedalPosition.java
@@ -34,6 +34,6 @@ public class AcceleratorPedalPosition extends Asn1Integer {
   @JsonCreator
   public AcceleratorPedalPosition(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/BrakePedalPosition.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/BrakePedalPosition.java
@@ -34,6 +34,6 @@ public class BrakePedalPosition extends Asn1Integer {
   @JsonCreator
   public BrakePedalPosition(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/ManeuverID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/ManeuverID.java
@@ -41,7 +41,7 @@ public class ManeuverID extends Asn1Integer {
   @JsonCreator
   public ManeuverID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -91,7 +91,7 @@ public class ManeuverID extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<ManeuverID> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/MaxAvailableAcceleration.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/MaxAvailableAcceleration.java
@@ -34,6 +34,6 @@ public class MaxAvailableAcceleration extends Asn1Integer {
   @JsonCreator
   public MaxAvailableAcceleration(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/MaxAvailableDeceleration.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/MaxAvailableDeceleration.java
@@ -34,6 +34,6 @@ public class MaxAvailableDeceleration extends Asn1Integer {
   @JsonCreator
   public MaxAvailableDeceleration(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/PartII_Id.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/PartII_Id.java
@@ -34,6 +34,6 @@ public class PartII_Id extends Asn1Integer {
   @JsonCreator
   public PartII_Id(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/Pitch.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/Pitch.java
@@ -34,6 +34,6 @@ public class Pitch extends Asn1Integer {
   @JsonCreator
   public Pitch(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/PitchRate.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/PitchRate.java
@@ -34,6 +34,6 @@ public class PitchRate extends Asn1Integer {
   @JsonCreator
   public PitchRate(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/RoadGrade.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/RoadGrade.java
@@ -34,6 +34,6 @@ public class RoadGrade extends Asn1Integer {
   @JsonCreator
   public RoadGrade(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/Roll.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/Roll.java
@@ -34,6 +34,6 @@ public class Roll extends Asn1Integer {
   @JsonCreator
   public Roll(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/RollRate.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/RollRate.java
@@ -34,6 +34,6 @@ public class RollRate extends Asn1Integer {
   @JsonCreator
   public RollRate(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/SeparationDistance.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/SeparationDistance.java
@@ -34,6 +34,6 @@ public class SeparationDistance extends Asn1Integer {
   @JsonCreator
   public SeparationDistance(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/TimeConstant.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/TimeConstant.java
@@ -34,6 +34,6 @@ public class TimeConstant extends Asn1Integer {
   @JsonCreator
   public TimeConstant(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/Torque.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/Torque.java
@@ -34,6 +34,6 @@ public class Torque extends Asn1Integer {
   @JsonCreator
   public Torque(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/TotalMass.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/TotalMass.java
@@ -34,6 +34,6 @@ public class TotalMass extends Asn1Integer {
   @JsonCreator
   public TotalMass(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/Yaw.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/Yaw.java
@@ -34,6 +34,6 @@ public class Yaw extends Asn1Integer {
   @JsonCreator
   public Yaw(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/AccountStatus.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/AccountStatus.java
@@ -41,7 +41,7 @@ public class AccountStatus extends Asn1Integer {
   @JsonCreator
   public AccountStatus(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -63,7 +63,7 @@ public class AccountStatus extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<AccountStatus> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ActualNumberOfPassengers.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ActualNumberOfPassengers.java
@@ -33,6 +33,6 @@ public class ActualNumberOfPassengers extends Int1Unsigned {
   @JsonCreator
   public ActualNumberOfPassengers(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Altitude.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Altitude.java
@@ -33,6 +33,6 @@ public class Altitude extends Int2Signed {
   @JsonCreator
   public Altitude(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/CO2EmissionValue.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/CO2EmissionValue.java
@@ -33,6 +33,6 @@ public class CO2EmissionValue extends Int2Unsigned {
   @JsonCreator
   public CO2EmissionValue(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ContractSerialNumber.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ContractSerialNumber.java
@@ -33,6 +33,6 @@ public class ContractSerialNumber extends Int4Unsigned {
   @JsonCreator
   public ContractSerialNumber(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/CopValue.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/CopValue.java
@@ -41,7 +41,7 @@ public class CopValue extends Asn1Integer {
   @JsonCreator
   public CopValue(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -67,7 +67,7 @@ public class CopValue extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<CopValue> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/DateCompact.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/DateCompact.java
@@ -61,7 +61,7 @@ public class DateCompact extends Asn1Sequence {
     @JsonCreator
     public YearInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -73,7 +73,7 @@ public class DateCompact extends Asn1Sequence {
     @JsonCreator
     public MonthInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -85,7 +85,7 @@ public class DateCompact extends Asn1Sequence {
     @JsonCreator
     public DayInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/DescriptiveCharacteristics.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/DescriptiveCharacteristics.java
@@ -41,7 +41,7 @@ public class DescriptiveCharacteristics extends Asn1Integer {
   @JsonCreator
   public DescriptiveCharacteristics(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -60,7 +60,7 @@ public class DescriptiveCharacteristics extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<DescriptiveCharacteristics> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/DetectionMode.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/DetectionMode.java
@@ -41,7 +41,7 @@ public class DetectionMode extends Asn1Integer {
   @JsonCreator
   public DetectionMode(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -62,7 +62,7 @@ public class DetectionMode extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<DetectionMode> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/DistanceUnit.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/DistanceUnit.java
@@ -41,7 +41,7 @@ public class DistanceUnit extends Asn1Integer {
   @JsonCreator
   public DistanceUnit(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -68,7 +68,7 @@ public class DistanceUnit extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<DistanceUnit> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/EfcContextMark.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/EfcContextMark.java
@@ -74,7 +74,7 @@ public class EfcContextMark extends Asn1Sequence {
     @JsonCreator
     public ContextVersionInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/EmissionUnit.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/EmissionUnit.java
@@ -41,7 +41,7 @@ public class EmissionUnit extends Asn1Integer {
   @JsonCreator
   public EmissionUnit(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -61,7 +61,7 @@ public class EmissionUnit extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<EmissionUnit> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/EngineCharacteristics.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/EngineCharacteristics.java
@@ -41,7 +41,7 @@ public class EngineCharacteristics extends Asn1Integer {
   @JsonCreator
   public EngineCharacteristics(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -113,7 +113,7 @@ public class EngineCharacteristics extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<EngineCharacteristics> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/EuroValue.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/EuroValue.java
@@ -41,7 +41,7 @@ public class EuroValue extends Asn1Integer {
   @JsonCreator
   public EuroValue(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -68,7 +68,7 @@ public class EuroValue extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<EuroValue> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ExhaustEmissionValues.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ExhaustEmissionValues.java
@@ -69,7 +69,7 @@ public class ExhaustEmissionValues extends Asn1Sequence {
     @JsonCreator
     public EmissionCoInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/FutureCharacteristics.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/FutureCharacteristics.java
@@ -41,7 +41,7 @@ public class FutureCharacteristics extends Asn1Integer {
   @JsonCreator
   public FutureCharacteristics(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -61,7 +61,7 @@ public class FutureCharacteristics extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<FutureCharacteristics> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int1Signed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int1Signed.java
@@ -34,6 +34,6 @@ public class Int1Signed extends Asn1Integer {
   @JsonCreator
   public Int1Signed(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int1Unsigned.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int1Unsigned.java
@@ -34,6 +34,6 @@ public class Int1Unsigned extends Asn1Integer {
   @JsonCreator
   public Int1Unsigned(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int2Signed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int2Signed.java
@@ -34,6 +34,6 @@ public class Int2Signed extends Asn1Integer {
   @JsonCreator
   public Int2Signed(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int2Unsigned.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int2Unsigned.java
@@ -34,6 +34,6 @@ public class Int2Unsigned extends Asn1Integer {
   @JsonCreator
   public Int2Unsigned(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int3Unsigned.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int3Unsigned.java
@@ -34,6 +34,6 @@ public class Int3Unsigned extends Asn1Integer {
   @JsonCreator
   public Int3Unsigned(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int4Signed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int4Signed.java
@@ -34,6 +34,6 @@ public class Int4Signed extends Asn1Integer {
   @JsonCreator
   public Int4Signed(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int4Unsigned.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int4Unsigned.java
@@ -34,6 +34,6 @@ public class Int4Unsigned extends Asn1Integer {
   @JsonCreator
   public Int4Unsigned(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int8Signed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int8Signed.java
@@ -34,6 +34,6 @@ public class Int8Signed extends Asn1Integer {
   @JsonCreator
   public Int8Signed(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int8Unsigned.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Int8Unsigned.java
@@ -34,6 +34,6 @@ public class Int8Unsigned extends Asn1Integer {
   @JsonCreator
   public Int8Unsigned(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/IssuerIdentifier.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/IssuerIdentifier.java
@@ -34,6 +34,6 @@ public class IssuerIdentifier extends Asn1Integer {
   @JsonCreator
   public IssuerIdentifier(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Latitude.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Latitude.java
@@ -33,6 +33,6 @@ public class Latitude extends Int4Signed {
   @JsonCreator
   public Latitude(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/LocalVehicleClassId.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/LocalVehicleClassId.java
@@ -33,6 +33,6 @@ public class LocalVehicleClassId extends Int2Unsigned {
   @JsonCreator
   public LocalVehicleClassId(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/LocationClassId.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/LocationClassId.java
@@ -33,6 +33,6 @@ public class LocationClassId extends Int4Unsigned {
   @JsonCreator
   public LocationClassId(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Longitude.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Longitude.java
@@ -33,6 +33,6 @@ public class Longitude extends Int4Signed {
   @JsonCreator
   public Longitude(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/NumberOfAxles.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/NumberOfAxles.java
@@ -57,7 +57,7 @@ public class NumberOfAxles extends Asn1Sequence {
     @JsonCreator
     public TrailerAxlesInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -69,7 +69,7 @@ public class NumberOfAxles extends Asn1Sequence {
     @JsonCreator
     public TractorAxlesInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Particulate.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Particulate.java
@@ -57,7 +57,7 @@ public class Particulate extends Asn1Sequence {
     @JsonCreator
     public ValueInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ReceiptData.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ReceiptData.java
@@ -114,7 +114,7 @@ public class ReceiptData extends Asn1Sequence {
     @JsonCreator
     public SessionContextVersionInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ReceiptDistance.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ReceiptDistance.java
@@ -33,6 +33,6 @@ public class ReceiptDistance extends Int3Unsigned {
   @JsonCreator
   public ReceiptDistance(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ReceiptServicePart.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ReceiptServicePart.java
@@ -78,7 +78,7 @@ public class ReceiptServicePart extends Asn1Sequence {
     @JsonCreator
     public StationLocationInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ReceiptServiceSerialNumber.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ReceiptServiceSerialNumber.java
@@ -33,6 +33,6 @@ public class ReceiptServiceSerialNumber extends Int3Unsigned {
   @JsonCreator
   public ReceiptServiceSerialNumber(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ResultOp.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/ResultOp.java
@@ -41,7 +41,7 @@ public class ResultOp extends Asn1Integer {
   @JsonCreator
   public ResultOp(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -85,7 +85,7 @@ public class ResultOp extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<ResultOp> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/SessionLocation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/SessionLocation.java
@@ -58,7 +58,7 @@ public class SessionLocation extends Asn1Sequence {
     @JsonCreator
     public LaneCodeNumberInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/SignedValue.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/SignedValue.java
@@ -57,7 +57,7 @@ public class SignedValue extends Asn1Choice {
     @JsonCreator
     public PositiveInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -69,7 +69,7 @@ public class SignedValue extends Asn1Choice {
     @JsonCreator
     public NegativeInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/StationType.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/StationType.java
@@ -41,7 +41,7 @@ public class StationType extends Asn1Integer {
   @JsonCreator
   public StationType(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -75,7 +75,7 @@ public class StationType extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<StationType> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TariffClassId.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TariffClassId.java
@@ -33,6 +33,6 @@ public class TariffClassId extends Int4Unsigned {
   @JsonCreator
   public TariffClassId(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Time.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Time.java
@@ -33,6 +33,6 @@ public class Time extends Int4Unsigned {
   @JsonCreator
   public Time(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TimeClassId.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TimeClassId.java
@@ -33,6 +33,6 @@ public class TimeClassId extends Int2Unsigned {
   @JsonCreator
   public TimeClassId(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TimeCompact.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TimeCompact.java
@@ -61,7 +61,7 @@ public class TimeCompact extends Asn1Sequence {
     @JsonCreator
     public HoursInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -73,7 +73,7 @@ public class TimeCompact extends Asn1Sequence {
     @JsonCreator
     public MinsInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -85,7 +85,7 @@ public class TimeCompact extends Asn1Sequence {
     @JsonCreator
     public DoubleSecsInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TimeUnit.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TimeUnit.java
@@ -41,7 +41,7 @@ public class TimeUnit extends Asn1Integer {
   @JsonCreator
   public TimeUnit(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -64,7 +64,7 @@ public class TimeUnit extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<TimeUnit> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TrailerDetails.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TrailerDetails.java
@@ -57,7 +57,7 @@ public class TrailerDetails extends Asn1Sequence {
     @JsonCreator
     public TrailerAxlesInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TrailerType.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TrailerType.java
@@ -41,7 +41,7 @@ public class TrailerType extends Asn1Integer {
   @JsonCreator
   public TrailerType(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -62,7 +62,7 @@ public class TrailerType extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<TrailerType> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TyreConfiguration.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/TyreConfiguration.java
@@ -41,7 +41,7 @@ public class TyreConfiguration extends Asn1Integer {
   @JsonCreator
   public TyreConfiguration(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -63,7 +63,7 @@ public class TyreConfiguration extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<TyreConfiguration> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/UserClassId.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/UserClassId.java
@@ -33,6 +33,6 @@ public class UserClassId extends Int1Unsigned {
   @JsonCreator
   public UserClassId(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/VehicleClass.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/VehicleClass.java
@@ -33,6 +33,6 @@ public class VehicleClass extends Int1Unsigned {
   @JsonCreator
   public VehicleClass(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/VehicleCurrentMaxTrainWeight.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/VehicleCurrentMaxTrainWeight.java
@@ -33,6 +33,6 @@ public class VehicleCurrentMaxTrainWeight extends Int2Unsigned {
   @JsonCreator
   public VehicleCurrentMaxTrainWeight(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/VehicleTotalDistance.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/VehicleTotalDistance.java
@@ -33,6 +33,6 @@ public class VehicleTotalDistance extends Int4Unsigned {
   @JsonCreator
   public VehicleTotalDistance(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/VehicleWeightLaden.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/VehicleWeightLaden.java
@@ -33,6 +33,6 @@ public class VehicleWeightLaden extends Int2Unsigned {
   @JsonCreator
   public VehicleWeightLaden(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Weekday.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/Weekday.java
@@ -41,7 +41,7 @@ public class Weekday extends Asn1Integer {
   @JsonCreator
   public Weekday(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -67,7 +67,7 @@ public class Weekday extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Weekday> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ITIS/ITIScodes.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ITIS/ITIScodes.java
@@ -34,6 +34,6 @@ public class ITIScodes extends Asn1Integer {
   @JsonCreator
   public ITIScodes(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/AccidentsAndIncidents.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/AccidentsAndIncidents.java
@@ -41,7 +41,7 @@ public class AccidentsAndIncidents extends Asn1Integer {
   @JsonCreator
   public AccidentsAndIncidents(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -111,7 +111,7 @@ public class AccidentsAndIncidents extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<AccidentsAndIncidents> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/AdviceInstructionsMandatory.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/AdviceInstructionsMandatory.java
@@ -41,7 +41,7 @@ public class AdviceInstructionsMandatory extends Asn1Integer {
   @JsonCreator
   public AdviceInstructionsMandatory(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -90,7 +90,7 @@ public class AdviceInstructionsMandatory extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<AdviceInstructionsMandatory> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/AdviceInstructionsRecommendations.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/AdviceInstructionsRecommendations.java
@@ -41,7 +41,7 @@ public class AdviceInstructionsRecommendations extends Asn1Integer {
   @JsonCreator
   public AdviceInstructionsRecommendations(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -96,7 +96,7 @@ public class AdviceInstructionsRecommendations extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<AdviceInstructionsRecommendations> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/AlternateRoute.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/AlternateRoute.java
@@ -41,7 +41,7 @@ public class AlternateRoute extends Asn1Integer {
   @JsonCreator
   public AlternateRoute(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -82,7 +82,7 @@ public class AlternateRoute extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<AlternateRoute> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/AssetStatus.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/AssetStatus.java
@@ -41,7 +41,7 @@ public class AssetStatus extends Asn1Integer {
   @JsonCreator
   public AssetStatus(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -78,7 +78,7 @@ public class AssetStatus extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<AssetStatus> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Closures.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Closures.java
@@ -41,7 +41,7 @@ public class Closures extends Asn1Integer {
   @JsonCreator
   public Closures(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -77,7 +77,7 @@ public class Closures extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Closures> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/DelayStatusCancellation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/DelayStatusCancellation.java
@@ -41,7 +41,7 @@ public class DelayStatusCancellation extends Asn1Integer {
   @JsonCreator
   public DelayStatusCancellation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -95,7 +95,7 @@ public class DelayStatusCancellation extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<DelayStatusCancellation> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/DeviceStatus.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/DeviceStatus.java
@@ -41,7 +41,7 @@ public class DeviceStatus extends Asn1Integer {
   @JsonCreator
   public DeviceStatus(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -100,7 +100,7 @@ public class DeviceStatus extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<DeviceStatus> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Disasters.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Disasters.java
@@ -41,7 +41,7 @@ public class Disasters extends Asn1Integer {
   @JsonCreator
   public Disasters(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -91,7 +91,7 @@ public class Disasters extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Disasters> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Disturbances.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Disturbances.java
@@ -41,7 +41,7 @@ public class Disturbances extends Asn1Integer {
   @JsonCreator
   public Disturbances(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -96,7 +96,7 @@ public class Disturbances extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Disturbances> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/GenericLocations.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/GenericLocations.java
@@ -41,7 +41,7 @@ public class GenericLocations extends Asn1Integer {
   @JsonCreator
   public GenericLocations(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -156,7 +156,7 @@ public class GenericLocations extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<GenericLocations> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/ITIScodes.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/ITIScodes.java
@@ -41,7 +41,7 @@ public class ITIScodes extends Asn1Integer {
   @JsonCreator
   public ITIScodes(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -2515,7 +2515,7 @@ public class ITIScodes extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<ITIScodes> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/ITISgroups.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/ITISgroups.java
@@ -41,7 +41,7 @@ public class ITISgroups extends Asn1Integer {
   @JsonCreator
   public ITISgroups(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -112,7 +112,7 @@ public class ITISgroups extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<ITISgroups> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/IncidentResponseEquipment.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/IncidentResponseEquipment.java
@@ -41,7 +41,7 @@ public class IncidentResponseEquipment extends Asn1Integer {
   @JsonCreator
   public IncidentResponseEquipment(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -132,7 +132,7 @@ public class IncidentResponseEquipment extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<IncidentResponseEquipment> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/IncidentResponseStatus.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/IncidentResponseStatus.java
@@ -41,7 +41,7 @@ public class IncidentResponseStatus extends Asn1Integer {
   @JsonCreator
   public IncidentResponseStatus(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -76,7 +76,7 @@ public class IncidentResponseStatus extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<IncidentResponseStatus> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/LaneRoadway.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/LaneRoadway.java
@@ -41,7 +41,7 @@ public class LaneRoadway extends Asn1Integer {
   @JsonCreator
   public LaneRoadway(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -120,7 +120,7 @@ public class LaneRoadway extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<LaneRoadway> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/LargeNumbers.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/LargeNumbers.java
@@ -41,7 +41,7 @@ public class LargeNumbers extends Asn1Integer {
   @JsonCreator
   public LargeNumbers(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -149,7 +149,7 @@ public class LargeNumbers extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<LargeNumbers> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/MUTCDLocations.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/MUTCDLocations.java
@@ -41,7 +41,7 @@ public class MUTCDLocations extends Asn1Integer {
   @JsonCreator
   public MUTCDLocations(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -128,7 +128,7 @@ public class MUTCDLocations extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<MUTCDLocations> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/MobileSituation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/MobileSituation.java
@@ -41,7 +41,7 @@ public class MobileSituation extends Asn1Integer {
   @JsonCreator
   public MobileSituation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -81,7 +81,7 @@ public class MobileSituation extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<MobileSituation> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/NamedObjects.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/NamedObjects.java
@@ -41,7 +41,7 @@ public class NamedObjects extends Asn1Integer {
   @JsonCreator
   public NamedObjects(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -84,7 +84,7 @@ public class NamedObjects extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<NamedObjects> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Objects.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Objects.java
@@ -41,7 +41,7 @@ public class Objects extends Asn1Integer {
   @JsonCreator
   public Objects(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -113,7 +113,7 @@ public class Objects extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Objects> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Obstruction.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Obstruction.java
@@ -41,7 +41,7 @@ public class Obstruction extends Asn1Integer {
   @JsonCreator
   public Obstruction(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -99,7 +99,7 @@ public class Obstruction extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Obstruction> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/ParkingInformation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/ParkingInformation.java
@@ -41,7 +41,7 @@ public class ParkingInformation extends Asn1Integer {
   @JsonCreator
   public ParkingInformation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -93,7 +93,7 @@ public class ParkingInformation extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<ParkingInformation> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/PavementConditions.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/PavementConditions.java
@@ -41,7 +41,7 @@ public class PavementConditions extends Asn1Integer {
   @JsonCreator
   public PavementConditions(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -114,7 +114,7 @@ public class PavementConditions extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<PavementConditions> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Precipitation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Precipitation.java
@@ -41,7 +41,7 @@ public class Precipitation extends Asn1Integer {
   @JsonCreator
   public Precipitation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -85,7 +85,7 @@ public class Precipitation extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Precipitation> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Qualifiers.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Qualifiers.java
@@ -41,7 +41,7 @@ public class Qualifiers extends Asn1Integer {
   @JsonCreator
   public Qualifiers(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -146,7 +146,7 @@ public class Qualifiers extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Qualifiers> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/RecreationalObjectsAndActivities.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/RecreationalObjectsAndActivities.java
@@ -41,7 +41,7 @@ public class RecreationalObjectsAndActivities extends Asn1Integer {
   @JsonCreator
   public RecreationalObjectsAndActivities(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -122,7 +122,7 @@ public class RecreationalObjectsAndActivities extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<RecreationalObjectsAndActivities> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/RegulatoryAndWarningSigns.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/RegulatoryAndWarningSigns.java
@@ -41,7 +41,7 @@ public class RegulatoryAndWarningSigns extends Asn1Integer {
   @JsonCreator
   public RegulatoryAndWarningSigns(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -101,7 +101,7 @@ public class RegulatoryAndWarningSigns extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<RegulatoryAndWarningSigns> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/ResponderGroupAffected.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/ResponderGroupAffected.java
@@ -41,7 +41,7 @@ public class ResponderGroupAffected extends Asn1Integer {
   @JsonCreator
   public ResponderGroupAffected(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -74,7 +74,7 @@ public class ResponderGroupAffected extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<ResponderGroupAffected> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/RestrictionClass.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/RestrictionClass.java
@@ -41,7 +41,7 @@ public class RestrictionClass extends Asn1Integer {
   @JsonCreator
   public RestrictionClass(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -100,7 +100,7 @@ public class RestrictionClass extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<RestrictionClass> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/RoadsideAssets.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/RoadsideAssets.java
@@ -41,7 +41,7 @@ public class RoadsideAssets extends Asn1Integer {
   @JsonCreator
   public RoadsideAssets(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -137,7 +137,7 @@ public class RoadsideAssets extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<RoadsideAssets> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Roadwork.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Roadwork.java
@@ -41,7 +41,7 @@ public class Roadwork extends Asn1Integer {
   @JsonCreator
   public Roadwork(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -103,7 +103,7 @@ public class Roadwork extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Roadwork> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/SmallNumbers.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/SmallNumbers.java
@@ -41,7 +41,7 @@ public class SmallNumbers extends Asn1Integer {
   @JsonCreator
   public SmallNumbers(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -314,7 +314,7 @@ public class SmallNumbers extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<SmallNumbers> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/SpecialEvents.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/SpecialEvents.java
@@ -41,7 +41,7 @@ public class SpecialEvents extends Asn1Integer {
   @JsonCreator
   public SpecialEvents(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -82,7 +82,7 @@ public class SpecialEvents extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<SpecialEvents> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/SportingEvents.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/SportingEvents.java
@@ -41,7 +41,7 @@ public class SportingEvents extends Asn1Integer {
   @JsonCreator
   public SportingEvents(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -84,7 +84,7 @@ public class SportingEvents extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<SportingEvents> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/StatesAndTerritories.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/StatesAndTerritories.java
@@ -41,7 +41,7 @@ public class StatesAndTerritories extends Asn1Integer {
   @JsonCreator
   public StatesAndTerritories(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -115,7 +115,7 @@ public class StatesAndTerritories extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<StatesAndTerritories> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/StreetSuffixes.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/StreetSuffixes.java
@@ -41,7 +41,7 @@ public class StreetSuffixes extends Asn1Integer {
   @JsonCreator
   public StreetSuffixes(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -204,7 +204,7 @@ public class StreetSuffixes extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<StreetSuffixes> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Structures.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Structures.java
@@ -41,7 +41,7 @@ public class Structures extends Asn1Integer {
   @JsonCreator
   public Structures(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -86,7 +86,7 @@ public class Structures extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Structures> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/SuggestionAdvice.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/SuggestionAdvice.java
@@ -41,7 +41,7 @@ public class SuggestionAdvice extends Asn1Integer {
   @JsonCreator
   public SuggestionAdvice(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -81,7 +81,7 @@ public class SuggestionAdvice extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<SuggestionAdvice> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/SystemInformation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/SystemInformation.java
@@ -41,7 +41,7 @@ public class SystemInformation extends Asn1Integer {
   @JsonCreator
   public SystemInformation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -75,7 +75,7 @@ public class SystemInformation extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<SystemInformation> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Temperature.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Temperature.java
@@ -41,7 +41,7 @@ public class Temperature extends Asn1Integer {
   @JsonCreator
   public Temperature(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -82,7 +82,7 @@ public class Temperature extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Temperature> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/TrafficConditions.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/TrafficConditions.java
@@ -41,7 +41,7 @@ public class TrafficConditions extends Asn1Integer {
   @JsonCreator
   public TrafficConditions(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -80,7 +80,7 @@ public class TrafficConditions extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<TrafficConditions> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/TransitMode.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/TransitMode.java
@@ -41,7 +41,7 @@ public class TransitMode extends Asn1Integer {
   @JsonCreator
   public TransitMode(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -85,7 +85,7 @@ public class TransitMode extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<TransitMode> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/TransitOperations.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/TransitOperations.java
@@ -41,7 +41,7 @@ public class TransitOperations extends Asn1Integer {
   @JsonCreator
   public TransitOperations(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -112,7 +112,7 @@ public class TransitOperations extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<TransitOperations> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/TravelerGroupAffected.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/TravelerGroupAffected.java
@@ -41,7 +41,7 @@ public class TravelerGroupAffected extends Asn1Integer {
   @JsonCreator
   public TravelerGroupAffected(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -74,7 +74,7 @@ public class TravelerGroupAffected extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<TravelerGroupAffected> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Units.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Units.java
@@ -41,7 +41,7 @@ public class Units extends Asn1Integer {
   @JsonCreator
   public Units(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -122,7 +122,7 @@ public class Units extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Units> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/UnusualDriving.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/UnusualDriving.java
@@ -41,7 +41,7 @@ public class UnusualDriving extends Asn1Integer {
   @JsonCreator
   public UnusualDriving(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -67,7 +67,7 @@ public class UnusualDriving extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<UnusualDriving> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/ValidManeuvers.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/ValidManeuvers.java
@@ -41,7 +41,7 @@ public class ValidManeuvers extends Asn1Integer {
   @JsonCreator
   public ValidManeuvers(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -187,7 +187,7 @@ public class ValidManeuvers extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<ValidManeuvers> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/VehicleGroupAffected.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/VehicleGroupAffected.java
@@ -41,7 +41,7 @@ public class VehicleGroupAffected extends Asn1Integer {
   @JsonCreator
   public VehicleGroupAffected(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -104,7 +104,7 @@ public class VehicleGroupAffected extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<VehicleGroupAffected> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/VisibilityAndAirQuality.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/VisibilityAndAirQuality.java
@@ -41,7 +41,7 @@ public class VisibilityAndAirQuality extends Asn1Integer {
   @JsonCreator
   public VisibilityAndAirQuality(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -93,7 +93,7 @@ public class VisibilityAndAirQuality extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<VisibilityAndAirQuality> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/WarningAdvice.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/WarningAdvice.java
@@ -41,7 +41,7 @@ public class WarningAdvice extends Asn1Integer {
   @JsonCreator
   public WarningAdvice(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -109,7 +109,7 @@ public class WarningAdvice extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<WarningAdvice> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/WeatherConditions.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/WeatherConditions.java
@@ -41,7 +41,7 @@ public class WeatherConditions extends Asn1Integer {
   @JsonCreator
   public WeatherConditions(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -87,7 +87,7 @@ public class WeatherConditions extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<WeatherConditions> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Winds.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/Winds.java
@@ -41,7 +41,7 @@ public class Winds extends Asn1Integer {
   @JsonCreator
   public Winds(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -74,7 +74,7 @@ public class Winds extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<Winds> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/WinterDrivingIndex.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/WinterDrivingIndex.java
@@ -41,7 +41,7 @@ public class WinterDrivingIndex extends Asn1Integer {
   @JsonCreator
   public WinterDrivingIndex(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -65,7 +65,7 @@ public class WinterDrivingIndex extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<WinterDrivingIndex> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/WinterDrivingRestrictions.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/J2540ITIS/WinterDrivingRestrictions.java
@@ -41,7 +41,7 @@ public class WinterDrivingRestrictions extends Asn1Integer {
   @JsonCreator
   public WinterDrivingRestrictions(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -72,7 +72,7 @@ public class WinterDrivingRestrictions extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<WinterDrivingRestrictions> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ManeuverSharingAndCoordinatingMessage/ManeuverID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ManeuverSharingAndCoordinatingMessage/ManeuverID.java
@@ -34,6 +34,6 @@ public class ManeuverID extends Asn1Integer {
   @JsonCreator
   public ManeuverID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ManeuverSharingAndCoordinatingMessage/ObjectDistance.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ManeuverSharingAndCoordinatingMessage/ObjectDistance.java
@@ -34,6 +34,6 @@ public class ObjectDistance extends Asn1Integer {
   @JsonCreator
   public ObjectDistance(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ManeuverSharingAndCoordinatingMessage/TRRLength.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ManeuverSharingAndCoordinatingMessage/TRRLength.java
@@ -34,6 +34,6 @@ public class TRRLength extends Asn1Integer {
   @JsonCreator
   public TRRLength(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LayerID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LayerID.java
@@ -34,6 +34,6 @@ public class LayerID extends Asn1Integer {
   @JsonCreator
   public LayerID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MessageFrame/DSRCmsgID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MessageFrame/DSRCmsgID.java
@@ -41,7 +41,7 @@ public class DSRCmsgID extends Asn1Integer {
   @JsonCreator
   public DSRCmsgID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   private static class NamedValues {
@@ -126,7 +126,7 @@ public class DSRCmsgID extends Asn1Integer {
 
   @Override
   public Optional<String> name() {
-    return Optional.ofNullable(namedValues.valueMap.get(value));
+    return Optional.ofNullable(namedValues.valueMap.get(getValue()));
   }
 
   public static Optional<DSRCmsgID> named(String name) {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/NMEAcorrections/NMEA_MsgType.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/NMEAcorrections/NMEA_MsgType.java
@@ -34,6 +34,6 @@ public class NMEA_MsgType extends Asn1Integer {
   @JsonCreator
   public NMEA_MsgType(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/NMEAcorrections/ObjectCount.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/NMEAcorrections/ObjectCount.java
@@ -34,6 +34,6 @@ public class ObjectCount extends Asn1Integer {
   @JsonCreator
   public ObjectCount(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/NTCIP/EssMobileFriction.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/NTCIP/EssMobileFriction.java
@@ -34,6 +34,6 @@ public class EssMobileFriction extends Asn1Integer {
   @JsonCreator
   public EssMobileFriction(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/NTCIP/EssPrecipRate.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/NTCIP/EssPrecipRate.java
@@ -34,6 +34,6 @@ public class EssPrecipRate extends Asn1Integer {
   @JsonCreator
   public EssPrecipRate(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/NTCIP/EssSolarRadiation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/NTCIP/EssSolarRadiation.java
@@ -34,6 +34,6 @@ public class EssSolarRadiation extends Asn1Integer {
   @JsonCreator
   public EssSolarRadiation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/PersonalSafetyMessage/AttachmentRadius.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/PersonalSafetyMessage/AttachmentRadius.java
@@ -34,6 +34,6 @@ public class AttachmentRadius extends Asn1Integer {
   @JsonCreator
   public AttachmentRadius(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/PersonalSafetyMessage/PersonalClusterRadius.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/PersonalSafetyMessage/PersonalClusterRadius.java
@@ -34,6 +34,6 @@ public class PersonalClusterRadius extends Asn1Integer {
   @JsonCreator
   public PersonalClusterRadius(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgCommSysPerfEvents.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgCommSysPerfEvents.java
@@ -90,7 +90,7 @@ public class CfgCommSysPerfEvents extends Asn1Sequence {
     @JsonCreator
     public J2945_1ChanBusyThreshInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -102,7 +102,7 @@ public class CfgCommSysPerfEvents extends Asn1Sequence {
     @JsonCreator
     public NumRsusObservedThreshInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -114,7 +114,7 @@ public class CfgCommSysPerfEvents extends Asn1Sequence {
     @JsonCreator
     public RfV2xJamDetectThreshInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -126,7 +126,7 @@ public class CfgCommSysPerfEvents extends Asn1Sequence {
     @JsonCreator
     public J2945_1VehDensThreshInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -138,7 +138,7 @@ public class CfgCommSysPerfEvents extends Asn1Sequence {
     @JsonCreator
     public J2945_1CqiBelowThreshInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -150,7 +150,7 @@ public class CfgCommSysPerfEvents extends Asn1Sequence {
     @JsonCreator
     public J2945_1TrackErrorThreshInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -162,7 +162,7 @@ public class CfgCommSysPerfEvents extends Asn1Sequence {
     @JsonCreator
     public GnssHdopExceedsThreshInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -174,7 +174,7 @@ public class CfgCommSysPerfEvents extends Asn1Sequence {
     @JsonCreator
     public GnssSatsBelowThreshInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgEvents.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgEvents.java
@@ -70,7 +70,7 @@ public class CfgEvents extends Asn1Sequence {
     @JsonCreator
     public SwerveThresholdInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgHysteresis.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgHysteresis.java
@@ -57,7 +57,7 @@ public class CfgHysteresis extends Asn1Sequence {
     @JsonCreator
     public HysSamplesInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -69,7 +69,7 @@ public class CfgHysteresis extends Asn1Sequence {
     @JsonCreator
     public HysRateInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgInterval.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgInterval.java
@@ -62,7 +62,7 @@ public class CfgInterval extends Asn1Choice {
     @JsonCreator
     public TimeIntervalInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -74,7 +74,7 @@ public class CfgInterval extends Asn1Choice {
     @JsonCreator
     public DistanceIntervalInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgLowSpeedCriteria.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgLowSpeedCriteria.java
@@ -57,7 +57,7 @@ public class CfgLowSpeedCriteria extends Asn1Sequence {
     @JsonCreator
     public LowSpeedThresholdInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -69,7 +69,7 @@ public class CfgLowSpeedCriteria extends Asn1Sequence {
     @JsonCreator
     public LowSpeedTimeThreshInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgRoadSignInfo.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgRoadSignInfo.java
@@ -61,7 +61,7 @@ public class CfgRoadSignInfo extends Asn1Sequence {
     @JsonCreator
     public LowRoadsignReflect1Integer(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -73,7 +73,7 @@ public class CfgRoadSignInfo extends Asn1Sequence {
     @JsonCreator
     public LowRoadsignReflect2Integer(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgRoadwayEvents.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgRoadwayEvents.java
@@ -106,7 +106,7 @@ public class CfgRoadwayEvents extends Asn1Sequence {
     @JsonCreator
     public LowLaneMarkReflectInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgStoppedCriteria.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgStoppedCriteria.java
@@ -57,7 +57,7 @@ public class CfgStoppedCriteria extends Asn1Sequence {
     @JsonCreator
     public StoppedSpeedThresholdInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -69,7 +69,7 @@ public class CfgStoppedCriteria extends Asn1Sequence {
     @JsonCreator
     public AmountOfTimeBelowInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgTrafficSigEncounters.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgTrafficSigEncounters.java
@@ -95,7 +95,7 @@ public class CfgTrafficSigEncounters extends Asn1Sequence {
     @JsonCreator
     public TrfcsigApproachDelayInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -107,7 +107,7 @@ public class CfgTrafficSigEncounters extends Asn1Sequence {
     @JsonCreator
     public TrfsigApproachSpeedInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -119,7 +119,7 @@ public class CfgTrafficSigEncounters extends Asn1Sequence {
     @JsonCreator
     public TrfsigPedDelayInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgVehicleEvents.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/CfgVehicleEvents.java
@@ -98,7 +98,7 @@ public class CfgVehicleEvents extends Asn1Sequence {
     @JsonCreator
     public ResumedSpeedInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/ConfigDescriptor.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/ConfigDescriptor.java
@@ -66,7 +66,7 @@ public class ConfigDescriptor extends Asn1Sequence {
     @JsonCreator
     public PercentOfRespInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/ConfigId.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/ConfigId.java
@@ -34,6 +34,6 @@ public class ConfigId extends Asn1Integer {
   @JsonCreator
   public ConfigId(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/ProbeDataConfig.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataConfig/ProbeDataConfig.java
@@ -65,7 +65,7 @@ public class ProbeDataConfig extends Asn1Sequence {
     @JsonCreator
     public MaxAgeOfDataInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/GrossDistance.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/GrossDistance.java
@@ -34,6 +34,6 @@ public class GrossDistance extends Asn1Integer {
   @JsonCreator
   public GrossDistance(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/Sample.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/Sample.java
@@ -57,7 +57,7 @@ public class Sample extends Asn1Sequence {
     @JsonCreator
     public SampleStartInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -69,7 +69,7 @@ public class Sample extends Asn1Sequence {
     @JsonCreator
     public SampleEndInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/SecondOfTime.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/SecondOfTime.java
@@ -34,6 +34,6 @@ public class SecondOfTime extends Asn1Integer {
   @JsonCreator
   public SecondOfTime(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/TermDistance.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/TermDistance.java
@@ -34,6 +34,6 @@ public class TermDistance extends Asn1Integer {
   @JsonCreator
   public TermDistance(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/TermTime.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/TermTime.java
@@ -34,6 +34,6 @@ public class TermTime extends Asn1Integer {
   @JsonCreator
   public TermTime(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/VehicleStatusRequest.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataManagement/VehicleStatusRequest.java
@@ -70,7 +70,7 @@ public class VehicleStatusRequest extends Asn1Sequence {
     @JsonCreator
     public SubTypeInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -82,7 +82,7 @@ public class VehicleStatusRequest extends Asn1Sequence {
     @JsonCreator
     public SendOnLessThenValueInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -94,7 +94,7 @@ public class VehicleStatusRequest extends Asn1Sequence {
     @JsonCreator
     public SendOnMoreThenValueInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/MeanVariation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/MeanVariation.java
@@ -34,6 +34,6 @@ public class MeanVariation extends Asn1Integer {
   @JsonCreator
   public MeanVariation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/ReportCharacteristics.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/ReportCharacteristics.java
@@ -90,7 +90,7 @@ public class ReportCharacteristics extends Asn1Sequence {
     @JsonCreator
     public VehPassengerCountInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptAveragedRecord.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptAveragedRecord.java
@@ -78,7 +78,7 @@ public class RptAveragedRecord extends Asn1Sequence {
     @JsonCreator
     public AvgStopDurationInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -90,7 +90,7 @@ public class RptAveragedRecord extends Asn1Sequence {
     @JsonCreator
     public AvgFuelConsumptionInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -102,7 +102,7 @@ public class RptAveragedRecord extends Asn1Sequence {
     @JsonCreator
     public AvgNumOfOccupantsInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptCommSysPerfEvents.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptCommSysPerfEvents.java
@@ -112,7 +112,7 @@ public class RptCommSysPerfEvents extends Asn1Choice {
     @JsonCreator
     public NumOfRsusObservedInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptEmissions.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptEmissions.java
@@ -85,7 +85,7 @@ public class RptEmissions extends Asn1Sequence {
     @JsonCreator
     public HydrocarbonsInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -97,7 +97,7 @@ public class RptEmissions extends Asn1Sequence {
     @JsonCreator
     public CoInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -109,7 +109,7 @@ public class RptEmissions extends Asn1Sequence {
     @JsonCreator
     public Co2Integer(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -121,7 +121,7 @@ public class RptEmissions extends Asn1Sequence {
     @JsonCreator
     public NoInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -133,7 +133,7 @@ public class RptEmissions extends Asn1Sequence {
     @JsonCreator
     public No2Integer(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -145,7 +145,7 @@ public class RptEmissions extends Asn1Sequence {
     @JsonCreator
     public So2Integer(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -157,7 +157,7 @@ public class RptEmissions extends Asn1Sequence {
     @JsonCreator
     public O3Integer(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -169,7 +169,7 @@ public class RptEmissions extends Asn1Sequence {
     @JsonCreator
     public Pm10Integer(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -181,7 +181,7 @@ public class RptEmissions extends Asn1Sequence {
     @JsonCreator
     public Pm25Integer(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptIntervalEvents.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptIntervalEvents.java
@@ -73,7 +73,7 @@ public class RptIntervalEvents extends Asn1Sequence {
     @JsonCreator
     public VehCountInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -85,7 +85,7 @@ public class RptIntervalEvents extends Asn1Sequence {
     @JsonCreator
     public NumOfOccupantsInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptLocOfStops.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptLocOfStops.java
@@ -63,7 +63,7 @@ public class RptLocOfStops extends Asn1Sequence {
     @JsonCreator
     public DurationOfStopInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptSummaryRecord.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptSummaryRecord.java
@@ -97,7 +97,7 @@ public class RptSummaryRecord extends Asn1Sequence {
     @JsonCreator
     public RegTravelTimeInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -109,7 +109,7 @@ public class RptSummaryRecord extends Asn1Sequence {
     @JsonCreator
     public RegVehDistTraveledInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -121,7 +121,7 @@ public class RptSummaryRecord extends Asn1Sequence {
     @JsonCreator
     public RegVehTimeTraveledInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -133,7 +133,7 @@ public class RptSummaryRecord extends Asn1Sequence {
     @JsonCreator
     public FuelConsumptionInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -145,7 +145,7 @@ public class RptSummaryRecord extends Asn1Sequence {
     @JsonCreator
     public NumOfLowSpeedEventsInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -157,7 +157,7 @@ public class RptSummaryRecord extends Asn1Sequence {
     @JsonCreator
     public TimeStoppedInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -169,7 +169,7 @@ public class RptSummaryRecord extends Asn1Sequence {
     @JsonCreator
     public NumOfStoppedInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -181,7 +181,7 @@ public class RptSummaryRecord extends Asn1Sequence {
     @JsonCreator
     public RegNumOfVehPassedInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -193,7 +193,7 @@ public class RptSummaryRecord extends Asn1Sequence {
     @JsonCreator
     public RegNumOfSurpassedVehInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -205,7 +205,7 @@ public class RptSummaryRecord extends Asn1Sequence {
     @JsonCreator
     public TotalMsgsReceivedInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptTransitVehData.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/RptTransitVehData.java
@@ -61,7 +61,7 @@ public class RptTransitVehData extends Asn1Sequence {
     @JsonCreator
     public CurrNumPasngersInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -73,7 +73,7 @@ public class RptTransitVehData extends Asn1Sequence {
     @JsonCreator
     public AvgNumPasngersInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -85,7 +85,7 @@ public class RptTransitVehData extends Asn1Sequence {
     @JsonCreator
     public TrnstVehSchAdhInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/StdDev.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeDataReport/StdDev.java
@@ -34,6 +34,6 @@ public class StdDev extends Asn1Integer {
   @JsonCreator
   public StdDev(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/AxleLocation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/AxleLocation.java
@@ -34,6 +34,6 @@ public class AxleLocation extends Asn1Integer {
   @JsonCreator
   public AxleLocation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/AxleWeight.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/AxleWeight.java
@@ -34,6 +34,6 @@ public class AxleWeight extends Asn1Integer {
   @JsonCreator
   public AxleWeight(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/CargoWeight.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/CargoWeight.java
@@ -34,6 +34,6 @@ public class CargoWeight extends Asn1Integer {
   @JsonCreator
   public CargoWeight(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/DriveAxleLiftAirPressure.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/DriveAxleLiftAirPressure.java
@@ -34,6 +34,6 @@ public class DriveAxleLiftAirPressure extends Asn1Integer {
   @JsonCreator
   public DriveAxleLiftAirPressure(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/DriveAxleLocation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/DriveAxleLocation.java
@@ -34,6 +34,6 @@ public class DriveAxleLocation extends Asn1Integer {
   @JsonCreator
   public DriveAxleLocation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/DriveAxleLubePressure.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/DriveAxleLubePressure.java
@@ -34,6 +34,6 @@ public class DriveAxleLubePressure extends Asn1Integer {
   @JsonCreator
   public DriveAxleLubePressure(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/DriveAxleTemperature.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/DriveAxleTemperature.java
@@ -34,6 +34,6 @@ public class DriveAxleTemperature extends Asn1Integer {
   @JsonCreator
   public DriveAxleTemperature(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/DrivingWheelAngle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/DrivingWheelAngle.java
@@ -34,6 +34,6 @@ public class DrivingWheelAngle extends Asn1Integer {
   @JsonCreator
   public DrivingWheelAngle(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/ProbeSegmentNumber.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/ProbeSegmentNumber.java
@@ -34,6 +34,6 @@ public class ProbeSegmentNumber extends Asn1Integer {
   @JsonCreator
   public ProbeSegmentNumber(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/SteeringAxleLubePressure.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/SteeringAxleLubePressure.java
@@ -34,6 +34,6 @@ public class SteeringAxleLubePressure extends Asn1Integer {
   @JsonCreator
   public SteeringAxleLubePressure(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/SteeringAxleTemperature.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/SteeringAxleTemperature.java
@@ -34,6 +34,6 @@ public class SteeringAxleTemperature extends Asn1Integer {
   @JsonCreator
   public SteeringAxleTemperature(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/SteeringWheelAngleRateOfChange.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/SteeringWheelAngleRateOfChange.java
@@ -34,6 +34,6 @@ public class SteeringWheelAngleRateOfChange extends Asn1Integer {
   @JsonCreator
   public SteeringWheelAngleRateOfChange(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/SunSensor.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/SunSensor.java
@@ -34,6 +34,6 @@ public class SunSensor extends Asn1Integer {
   @JsonCreator
   public SunSensor(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/ThrottlePosition.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/ThrottlePosition.java
@@ -34,6 +34,6 @@ public class ThrottlePosition extends Asn1Integer {
   @JsonCreator
   public ThrottlePosition(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/TireLeakageRate.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/TireLeakageRate.java
@@ -34,6 +34,6 @@ public class TireLeakageRate extends Asn1Integer {
   @JsonCreator
   public TireLeakageRate(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/TireLocation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/TireLocation.java
@@ -34,6 +34,6 @@ public class TireLocation extends Asn1Integer {
   @JsonCreator
   public TireLocation(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/TirePressure.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/TirePressure.java
@@ -34,6 +34,6 @@ public class TirePressure extends Asn1Integer {
   @JsonCreator
   public TirePressure(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/TireTemp.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ProbeVehicleData/TireTemp.java
@@ -34,6 +34,6 @@ public class TireTemp extends Asn1Integer {
   @JsonCreator
   public TireTemp(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/AudioLink.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/AudioLink.java
@@ -66,7 +66,7 @@ public class AudioLink extends Asn1Sequence {
     @JsonCreator
     public AmChannelInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -78,7 +78,7 @@ public class AudioLink extends Asn1Sequence {
     @JsonCreator
     public FmChannelInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -90,7 +90,7 @@ public class AudioLink extends Asn1Sequence {
     @JsonCreator
     public SatelliteChannelInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/BankAngle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/BankAngle.java
@@ -34,6 +34,6 @@ public class BankAngle extends Asn1Integer {
   @JsonCreator
   public BankAngle(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/ElevOffset.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/ElevOffset.java
@@ -34,6 +34,6 @@ public class ElevOffset extends Asn1Integer {
   @JsonCreator
   public ElevOffset(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/HeadingDeg.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/HeadingDeg.java
@@ -34,6 +34,6 @@ public class HeadingDeg extends Asn1Integer {
   @JsonCreator
   public HeadingDeg(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/LatOffset.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/LatOffset.java
@@ -34,6 +34,6 @@ public class LatOffset extends Asn1Integer {
   @JsonCreator
   public LatOffset(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/LongOffset.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/LongOffset.java
@@ -34,6 +34,6 @@ public class LongOffset extends Asn1Integer {
   @JsonCreator
   public LongOffset(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/Path.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/Path.java
@@ -61,7 +61,7 @@ public class Path extends Asn1Sequence {
     @JsonCreator
     public PathWidthInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/RSMLanePosition.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/RSMLanePosition.java
@@ -34,6 +34,6 @@ public class RSMLanePosition extends Asn1Integer {
   @JsonCreator
   public RSMLanePosition(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/Radius.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/Radius.java
@@ -34,6 +34,6 @@ public class Radius extends Asn1Integer {
   @JsonCreator
   public Radius(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/Tolerance.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/Tolerance.java
@@ -34,6 +34,6 @@ public class Tolerance extends Asn1Integer {
   @JsonCreator
   public Tolerance(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadUserChargingConfigMessage/ConfigInfo.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadUserChargingConfigMessage/ConfigInfo.java
@@ -75,7 +75,7 @@ public class ConfigInfo extends Asn1Sequence {
     @JsonCreator
     public ConfigIDInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -87,7 +87,7 @@ public class ConfigInfo extends Asn1Sequence {
     @JsonCreator
     public ConfigVersionInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadUserChargingReportMessage/ItemizedChargerData.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadUserChargingReportMessage/ItemizedChargerData.java
@@ -72,7 +72,7 @@ public class ItemizedChargerData extends Asn1Sequence {
     @JsonCreator
     public ConfigIDInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadUserChargingReportMessage/TripInfo.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadUserChargingReportMessage/TripInfo.java
@@ -62,7 +62,7 @@ public class TripInfo extends Asn1Sequence {
     @JsonCreator
     public DistanceTraveledInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -74,7 +74,7 @@ public class TripInfo extends Asn1Sequence {
     @JsonCreator
     public TimeTraveledInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/AtmosPressureMeasurementStdDev.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/AtmosPressureMeasurementStdDev.java
@@ -34,6 +34,6 @@ public class AtmosPressureMeasurementStdDev extends Asn1Integer {
   @JsonCreator
   public AtmosPressureMeasurementStdDev(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/DewPointTempMeasurementStdDev.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/DewPointTempMeasurementStdDev.java
@@ -34,6 +34,6 @@ public class DewPointTempMeasurementStdDev extends Asn1Integer {
   @JsonCreator
   public DewPointTempMeasurementStdDev(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssAirTemperature.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssAirTemperature.java
@@ -34,6 +34,6 @@ public class NTCIPEssAirTemperature extends Asn1Integer {
   @JsonCreator
   public NTCIPEssAirTemperature(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssCloudSituationV4.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssCloudSituationV4.java
@@ -34,6 +34,6 @@ public class NTCIPEssCloudSituationV4 extends Asn1Integer {
   @JsonCreator
   public NTCIPEssCloudSituationV4(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssDewpointTemp.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssDewpointTemp.java
@@ -34,6 +34,6 @@ public class NTCIPEssDewpointTemp extends Asn1Integer {
   @JsonCreator
   public NTCIPEssDewpointTemp(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPaveTreatmentAmount.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPaveTreatmentAmount.java
@@ -34,6 +34,6 @@ public class NTCIPEssPaveTreatmentAmount extends Asn1Integer {
   @JsonCreator
   public NTCIPEssPaveTreatmentAmount(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPaveTreatmentWidth.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPaveTreatmentWidth.java
@@ -34,6 +34,6 @@ public class NTCIPEssPaveTreatmentWidth extends Asn1Integer {
   @JsonCreator
   public NTCIPEssPaveTreatmentWidth(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPavementTreatmentLatitude.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPavementTreatmentLatitude.java
@@ -34,6 +34,6 @@ public class NTCIPEssPavementTreatmentLatitude extends Asn1Integer {
   @JsonCreator
   public NTCIPEssPavementTreatmentLatitude(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPavementTreatmentLocation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPavementTreatmentLocation.java
@@ -34,6 +34,6 @@ public class NTCIPEssPavementTreatmentLocation extends IA5String {
   @JsonCreator
   public NTCIPEssPavementTreatmentLocation(String value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPavementTreatmentLocation.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPavementTreatmentLocation.java
@@ -34,6 +34,6 @@ public class NTCIPEssPavementTreatmentLocation extends IA5String {
   @JsonCreator
   public NTCIPEssPavementTreatmentLocation(String value) {
     this();
-    this.setValue(value);
+    this.value = value;
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPavementTreatmentLongitude.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPavementTreatmentLongitude.java
@@ -34,6 +34,6 @@ public class NTCIPEssPavementTreatmentLongitude extends Asn1Integer {
   @JsonCreator
   public NTCIPEssPavementTreatmentLongitude(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPercentProductMix.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPercentProductMix.java
@@ -34,6 +34,6 @@ public class NTCIPEssPercentProductMix extends Asn1Integer {
   @JsonCreator
   public NTCIPEssPercentProductMix(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPressureSensorAtmosphericPressure.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssPressureSensorAtmosphericPressure.java
@@ -34,6 +34,6 @@ public class NTCIPEssPressureSensorAtmosphericPressure extends Asn1Integer {
   @JsonCreator
   public NTCIPEssPressureSensorAtmosphericPressure(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssSurfaceIceOrWaterDepth.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssSurfaceIceOrWaterDepth.java
@@ -34,6 +34,6 @@ public class NTCIPEssSurfaceIceOrWaterDepth extends Asn1Integer {
   @JsonCreator
   public NTCIPEssSurfaceIceOrWaterDepth(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssSurfaceTemperature.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssSurfaceTemperature.java
@@ -34,6 +34,6 @@ public class NTCIPEssSurfaceTemperature extends Asn1Integer {
   @JsonCreator
   public NTCIPEssSurfaceTemperature(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssTemperatureSensorHeight.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssTemperatureSensorHeight.java
@@ -34,6 +34,6 @@ public class NTCIPEssTemperatureSensorHeight extends Asn1Integer {
   @JsonCreator
   public NTCIPEssTemperatureSensorHeight(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssTotalRadiationPeriod.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssTotalRadiationPeriod.java
@@ -34,6 +34,6 @@ public class NTCIPEssTotalRadiationPeriod extends Asn1Integer {
   @JsonCreator
   public NTCIPEssTotalRadiationPeriod(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssTotalRadiationV4.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssTotalRadiationV4.java
@@ -34,6 +34,6 @@ public class NTCIPEssTotalRadiationV4 extends Asn1Integer {
   @JsonCreator
   public NTCIPEssTotalRadiationV4(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssVisibility.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPEssVisibility.java
@@ -34,6 +34,6 @@ public class NTCIPEssVisibility extends Asn1Integer {
   @JsonCreator
   public NTCIPEssVisibility(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPHumiditySensorRelativeHumidity.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPHumiditySensorRelativeHumidity.java
@@ -34,6 +34,6 @@ public class NTCIPHumiditySensorRelativeHumidity extends Asn1Integer {
   @JsonCreator
   public NTCIPHumiditySensorRelativeHumidity(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorAvgDirection.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorAvgDirection.java
@@ -34,6 +34,6 @@ public class NTCIPWindSensorAvgDirection extends Asn1Integer {
   @JsonCreator
   public NTCIPWindSensorAvgDirection(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorAvgSpeed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorAvgSpeed.java
@@ -34,6 +34,6 @@ public class NTCIPWindSensorAvgSpeed extends Asn1Integer {
   @JsonCreator
   public NTCIPWindSensorAvgSpeed(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorGustDirection.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorGustDirection.java
@@ -34,6 +34,6 @@ public class NTCIPWindSensorGustDirection extends Asn1Integer {
   @JsonCreator
   public NTCIPWindSensorGustDirection(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorGustSpeed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorGustSpeed.java
@@ -34,6 +34,6 @@ public class NTCIPWindSensorGustSpeed extends Asn1Integer {
   @JsonCreator
   public NTCIPWindSensorGustSpeed(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorSpotDirection.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorSpotDirection.java
@@ -34,6 +34,6 @@ public class NTCIPWindSensorSpotDirection extends Asn1Integer {
   @JsonCreator
   public NTCIPWindSensorSpotDirection(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorSpotSpeed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/NTCIPWindSensorSpotSpeed.java
@@ -34,6 +34,6 @@ public class NTCIPWindSensorSpotSpeed extends Asn1Integer {
   @JsonCreator
   public NTCIPWindSensorSpotSpeed(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/SurfaceTempMeasurementStdDev.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/SurfaceTempMeasurementStdDev.java
@@ -34,6 +34,6 @@ public class SurfaceTempMeasurementStdDev extends Asn1Integer {
   @JsonCreator
   public SurfaceTempMeasurementStdDev(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/TemperatureMeasurementStdDev.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadWeatherMessage/TemperatureMeasurementStdDev.java
@@ -34,6 +34,6 @@ public class TemperatureMeasurementStdDev extends Asn1Integer {
   @JsonCreator
   public TemperatureMeasurementStdDev(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/SpeedAdvice.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/SpeedAdvice.java
@@ -34,6 +34,6 @@ public class SpeedAdvice extends Asn1Integer {
   @JsonCreator
   public SpeedAdvice(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/TimeIntervalConfidence.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/TimeIntervalConfidence.java
@@ -34,6 +34,6 @@ public class TimeIntervalConfidence extends Asn1Integer {
   @JsonCreator
   public TimeIntervalConfidence(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/TimeMark.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/TimeMark.java
@@ -34,6 +34,6 @@ public class TimeMark extends Asn1Integer {
   @JsonCreator
   public TimeMark(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/ZoneLength.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/ZoneLength.java
@@ -34,6 +34,6 @@ public class ZoneLength extends Asn1Integer {
   @JsonCreator
   public ZoneLength(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/ClassificationConfidence.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/ClassificationConfidence.java
@@ -34,6 +34,6 @@ public class ClassificationConfidence extends Asn1Integer {
   @JsonCreator
   public ClassificationConfidence(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/MeasurementTimeOffset.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/MeasurementTimeOffset.java
@@ -34,6 +34,6 @@ public class MeasurementTimeOffset extends Asn1Integer {
   @JsonCreator
   public MeasurementTimeOffset(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/ObjectDistance.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/ObjectDistance.java
@@ -34,6 +34,6 @@ public class ObjectDistance extends Asn1Integer {
   @JsonCreator
   public ObjectDistance(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/ObjectID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/ObjectID.java
@@ -34,6 +34,6 @@ public class ObjectID extends Asn1Integer {
   @JsonCreator
   public ObjectID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/PitchDetected.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/PitchDetected.java
@@ -34,6 +34,6 @@ public class PitchDetected extends Asn1Integer {
   @JsonCreator
   public PitchDetected(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/PitchRate.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/PitchRate.java
@@ -34,6 +34,6 @@ public class PitchRate extends Asn1Integer {
   @JsonCreator
   public PitchRate(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/RollDetected.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/RollDetected.java
@@ -34,6 +34,6 @@ public class RollDetected extends Asn1Integer {
   @JsonCreator
   public RollDetected(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/RollRate.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/RollRate.java
@@ -34,6 +34,6 @@ public class RollRate extends Asn1Integer {
   @JsonCreator
   public RollRate(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/SizeValue.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/SizeValue.java
@@ -34,6 +34,6 @@ public class SizeValue extends Asn1Integer {
   @JsonCreator
   public SizeValue(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/YawDetected.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SensorDataSharingMessage/YawDetected.java
@@ -34,6 +34,6 @@ public class YawDetected extends Asn1Integer {
   @JsonCreator
   public YawDetected(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SignalRequestMessage/DeltaTime.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SignalRequestMessage/DeltaTime.java
@@ -34,6 +34,6 @@ public class DeltaTime extends Asn1Integer {
   @JsonCreator
   public DeltaTime(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/AckPolicy.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/AckPolicy.java
@@ -57,7 +57,7 @@ public class AckPolicy extends Asn1Sequence {
     @JsonCreator
     public TimeoutInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -69,7 +69,7 @@ public class AckPolicy extends Asn1Sequence {
     @JsonCreator
     public NumOfRetriesInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/AxlesCharges.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/AxlesCharges.java
@@ -58,7 +58,7 @@ public class AxlesCharges extends Asn1Sequence {
     @JsonCreator
     public AxlesLimitInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/ExitInfo.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/ExitInfo.java
@@ -61,7 +61,7 @@ public class ExitInfo extends Asn1Sequence {
     @JsonCreator
     public ExitNumberInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -73,7 +73,7 @@ public class ExitInfo extends Asn1Sequence {
     @JsonCreator
     public ExitLetterInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/PerAxleWeightCharges.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/PerAxleWeightCharges.java
@@ -71,7 +71,7 @@ public class PerAxleWeightCharges extends Asn1Sequence {
     @JsonCreator
     public TotalWeightLimitInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -83,7 +83,7 @@ public class PerAxleWeightCharges extends Asn1Sequence {
     @JsonCreator
     public MaxLadenWeightOnAxleInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TimeChargesTable.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TimeChargesTable.java
@@ -57,7 +57,7 @@ public class TimeChargesTable extends Asn1Sequence {
     @JsonCreator
     public MaxTimeInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TollAdvertisementInfo.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TollAdvertisementInfo.java
@@ -93,7 +93,7 @@ public class TollAdvertisementInfo extends Asn1Sequence {
     @JsonCreator
     public TotalTamsInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -105,7 +105,7 @@ public class TollAdvertisementInfo extends Asn1Sequence {
     @JsonCreator
     public TamNumInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TollPointID.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TollPointID.java
@@ -34,6 +34,6 @@ public class TollPointID extends Asn1Integer {
   @JsonCreator
   public TollPointID(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TollPointMap.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TollPointMap.java
@@ -81,7 +81,7 @@ public class TollPointMap extends Asn1Sequence {
     @JsonCreator
     public RevisionNumInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TotalWeightCharges.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TotalWeightCharges.java
@@ -67,7 +67,7 @@ public class TotalWeightCharges extends Asn1Sequence {
     @JsonCreator
     public WeightLimitInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TumInstructions.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollAdvertisementMessage/TumInstructions.java
@@ -57,7 +57,7 @@ public class TumInstructions extends Asn1Sequence {
     @JsonCreator
     public MaxNumOfLocTimeStampsInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -69,7 +69,7 @@ public class TumInstructions extends Asn1Sequence {
     @JsonCreator
     public LocTimeStampRateInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollUsageAckMessage/TollUsageAckMessage.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollUsageAckMessage/TollUsageAckMessage.java
@@ -61,7 +61,7 @@ public class TollUsageAckMessage extends Asn1Sequence {
     @JsonCreator
     public AckMaxAgeInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollUsageMessage/TollUserData.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollUsageMessage/TollUserData.java
@@ -109,7 +109,7 @@ public class TollUserData extends Asn1Sequence {
     @JsonCreator
     public NumOccupantsInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollUsageMessage/VehicleAxlesAndWeightInfo.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TollUsageMessage/VehicleAxlesAndWeightInfo.java
@@ -76,7 +76,7 @@ public class VehicleAxlesAndWeightInfo extends Asn1Sequence {
     @JsonCreator
     public VehNumAxlesInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -114,7 +114,7 @@ public class VehicleAxlesAndWeightInfo extends Asn1Sequence {
     @JsonCreator
     public SequenceOfVehWeightPerAxleInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 
@@ -127,7 +127,7 @@ public class VehicleAxlesAndWeightInfo extends Asn1Sequence {
     @JsonCreator
     public VehTotalWeightInteger(long value) {
       this();
-      this.value = value;
+      this.setValue(value);
     }
   }
 

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/TimeInSecond_B16.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/TimeInSecond_B16.java
@@ -34,6 +34,6 @@ public class TimeInSecond_B16 extends Asn1Integer {
   @JsonCreator
   public TimeInSecond_B16(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/TimeInSecond_B8.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/TimeInSecond_B8.java
@@ -34,6 +34,6 @@ public class TimeInSecond_B8 extends Asn1Integer {
   @JsonCreator
   public TimeInSecond_B8(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/TrafficLightDirectionCode.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/TrafficLightDirectionCode.java
@@ -34,6 +34,6 @@ public class TrafficLightDirectionCode extends Asn1Integer {
   @JsonCreator
   public TrafficLightDirectionCode(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/ITIStextPhrase.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/ITIStextPhrase.java
@@ -34,6 +34,6 @@ public class ITIStextPhrase extends IA5String {
   @JsonCreator
   public ITIStextPhrase(String value) {
     this();
-    this.setValue(value);
+    this.value = value;
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/ITIStextPhrase.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/ITIStextPhrase.java
@@ -34,6 +34,6 @@ public class ITIStextPhrase extends IA5String {
   @JsonCreator
   public ITIStextPhrase(String value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/MinutesDuration.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/MinutesDuration.java
@@ -34,6 +34,6 @@ public class MinutesDuration extends Asn1Integer {
   @JsonCreator
   public MinutesDuration(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/OffsetLL_B12.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/OffsetLL_B12.java
@@ -34,6 +34,6 @@ public class OffsetLL_B12 extends Asn1Integer {
   @JsonCreator
   public OffsetLL_B12(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/OffsetLL_B14.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/OffsetLL_B14.java
@@ -34,6 +34,6 @@ public class OffsetLL_B14 extends Asn1Integer {
   @JsonCreator
   public OffsetLL_B14(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/OffsetLL_B16.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/OffsetLL_B16.java
@@ -34,6 +34,6 @@ public class OffsetLL_B16 extends Asn1Integer {
   @JsonCreator
   public OffsetLL_B16(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/OffsetLL_B22.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/OffsetLL_B22.java
@@ -34,6 +34,6 @@ public class OffsetLL_B22 extends Asn1Integer {
   @JsonCreator
   public OffsetLL_B22(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/OffsetLL_B24.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/OffsetLL_B24.java
@@ -34,6 +34,6 @@ public class OffsetLL_B24 extends Asn1Integer {
   @JsonCreator
   public OffsetLL_B24(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/Radius_B12.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/Radius_B12.java
@@ -34,6 +34,6 @@ public class Radius_B12 extends Asn1Integer {
   @JsonCreator
   public Radius_B12(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/SignPriority.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/SignPriority.java
@@ -34,6 +34,6 @@ public class SignPriority extends Asn1Integer {
   @JsonCreator
   public SignPriority(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/Zoom.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TravelerInformation/Zoom.java
@@ -34,6 +34,6 @@ public class Zoom extends Asn1Integer {
   @JsonCreator
   public Zoom(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-runtime/src/main/java/us/dot/its/jpo/asn/runtime/types/Asn1Integer.java
+++ b/jpo-asn-runtime/src/main/java/us/dot/its/jpo/asn/runtime/types/Asn1Integer.java
@@ -14,11 +14,11 @@ import lombok.Setter;
 public class Asn1Integer implements Asn1Type, Comparable<Asn1Integer> {
 
   @Setter
-  protected long value;
+  private long value;
   @Getter
-  final long lowerBound;
+  private final long lowerBound;
   @Getter
-  final long upperBound;
+  private final long upperBound;
 
   public Asn1Integer() {
     this(Long.MIN_VALUE, Long.MAX_VALUE);
@@ -27,7 +27,7 @@ public class Asn1Integer implements Asn1Type, Comparable<Asn1Integer> {
   @JsonCreator
   public Asn1Integer(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 
   public Asn1Integer(long lowerBound, long upperBound) {
@@ -40,16 +40,12 @@ public class Asn1Integer implements Asn1Type, Comparable<Asn1Integer> {
     return value;
   }
 
-  public int intValue() {
-    return (int) value;
-  }
-
   @Override
   public int compareTo(Asn1Integer other) {
     if (other == null) {
       return -1;
     }
-    return Long.compare(value, other.value);
+    return Long.compare(getValue(), other.getValue());
   }
 
 
@@ -62,17 +58,17 @@ public class Asn1Integer implements Asn1Type, Comparable<Asn1Integer> {
       return false;
     }
     Asn1Integer that = (Asn1Integer) o;
-    return value == that.value;
+    return getValue() == that.getValue();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(value);
+    return Objects.hashCode(getValue());
   }
 
   @Override
   public String toString() {
-    return Long.toString(value);
+    return Long.toString(getValue());
   }
 
   public Optional<String> name() {

--- a/jpo-asn-runtime/src/test/java/us/dot/its/jpo/asn/runtime/examples/AInteger.java
+++ b/jpo-asn-runtime/src/test/java/us/dot/its/jpo/asn/runtime/examples/AInteger.java
@@ -12,6 +12,6 @@ public class AInteger extends Asn1Integer {
   @JsonCreator
   public AInteger(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-runtime/src/test/java/us/dot/its/jpo/asn/runtime/examples/BInteger.java
+++ b/jpo-asn-runtime/src/test/java/us/dot/its/jpo/asn/runtime/examples/BInteger.java
@@ -12,6 +12,6 @@ public class BInteger extends Asn1Integer {
   @JsonCreator
   public BInteger(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }

--- a/jpo-asn-runtime/src/test/java/us/dot/its/jpo/asn/runtime/examples/ExampleInteger.java
+++ b/jpo-asn-runtime/src/test/java/us/dot/its/jpo/asn/runtime/examples/ExampleInteger.java
@@ -12,6 +12,6 @@ public class ExampleInteger extends Asn1Integer {
   @JsonCreator
   public ExampleInteger(long value) {
     this();
-    this.value = value;
+    this.setValue(value);
   }
 }


### PR DESCRIPTION
Like the title says, this encapsulates the `value` property on the `Asn1Integer` base class. This is intended to unify property interactions and prevent unintentional behaviors caused by non-standard modifications to the value property.