### PR TITLE
Suggestions for "Suggestion: Refactor Deserializers"

### DIFF
--- a/jpo-asn-j2735-2024/build.gradle
+++ b/jpo-asn-j2735-2024/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id("io.freefair.lombok") version "8.12.1"
     id 'jacoco'
     id 'jacoco-report-aggregation'
+    id("com.diffplug.spotless") version "7.0.2"
 }
 
 group = 'usdot.jpo.asn'
@@ -66,4 +67,15 @@ tasks.named('check') {
     dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
 }
 
+spotless {
+    java {
+        target project.fileTree(project.rootDir) {
+            include '**/main/**/*.java'
+            exclude '**/package-info.java'
+            exclude '**/test/**/*.*'
+        }
+        googleJavaFormat('1.21.0').skipJavadocFormatting()
+    }
+}
 
+compileJava.dependsOn 'spotlessApply'

--- a/jpo-asn-j2735-2024/build.gradle
+++ b/jpo-asn-j2735-2024/build.gradle
@@ -69,11 +69,9 @@ tasks.named('check') {
 
 spotless {
     java {
-        target project.fileTree(project.rootDir) {
-            include '**/main/**/*.java'
-            exclude '**/package-info.java'
-            exclude '**/test/**/*.*'
-        }
+        targetExclude('**/package-info.java',
+             '**/test/**/*.*',
+             '**/resources/**/*.*')
         googleJavaFormat('1.21.0').skipJavadocFormatting()
     }
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/IsDolly.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/IsDolly.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.BasicSafetyMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class IsDolly extends Asn1Boolean {
-}
+public class IsDolly extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/PivotingAllowed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/BasicSafetyMessage/PivotingAllowed.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.BasicSafetyMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class PivotingAllowed extends Asn1Boolean {
-}
+public class PivotingAllowed extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/ExteriorLights.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/ExteriorLights.java
@@ -114,5 +114,4 @@ public class ExteriorLights extends Asn1Bitstring {
           "parkingLightsOn"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/GNSSstatus.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/GNSSstatus.java
@@ -105,5 +105,4 @@ public class GNSSstatus extends Asn1Bitstring {
           "networkCorrectionsPresent"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/HeadingSlice.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/HeadingSlice.java
@@ -177,5 +177,4 @@ public class HeadingSlice extends Asn1Bitstring {
           "from337-5to360-0degrees"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VehicleEventFlags.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VehicleEventFlags.java
@@ -159,5 +159,4 @@ public class VehicleEventFlags extends Asn1Bitstring {
           "eventJackKnife"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VerticalAccelerationThreshold.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/Common/VerticalAccelerationThreshold.java
@@ -70,5 +70,4 @@ public class VerticalAccelerationThreshold extends Asn1Bitstring {
     super(
         5, false, new String[] {"notEquipped", "leftFront", "leftRear", "rightFront", "rightRear"});
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/CCMFaultMode.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/CCMFaultMode.java
@@ -105,5 +105,4 @@ public class CCMFaultMode extends Asn1Bitstring {
           "engineCtlFault"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/FrontCutIn.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/CooperativeControlMessage/FrontCutIn.java
@@ -24,7 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.CooperativeControlMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class FrontCutIn extends Asn1Boolean {
-
-}
+public class FrontCutIn extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/CountryCode.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/CountryCode.java
@@ -29,5 +29,4 @@ public class CountryCode extends Asn1Bitstring {
   public CountryCode() {
     super(10, false, new String[] {});
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/EquipmentStatus.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/EfcDataDictionary/EquipmentStatus.java
@@ -24,7 +24,6 @@ package us.dot.its.jpo.asn.j2735.r2024.EfcDataDictionary;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Bitstring;
 
-
 public class EquipmentStatus extends Asn1Bitstring {
 
   public EquipmentStatus() {

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ManeuverSharingAndCoordinatingMessage/ResponseFlag.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ManeuverSharingAndCoordinatingMessage/ResponseFlag.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.ManeuverSharingAndCoordinatingMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class ResponseFlag extends Asn1Boolean {
-}
+public class ResponseFlag extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ManeuverSharingAndCoordinatingMessage/TemporaryIDPointer.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/ManeuverSharingAndCoordinatingMessage/TemporaryIDPointer.java
@@ -29,5 +29,4 @@ public class TemporaryIDPointer extends Asn1Bitstring {
   public TemporaryIDPointer() {
     super(1, 32, false, new String[] {});
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/AllowedManeuvers.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/AllowedManeuvers.java
@@ -141,5 +141,4 @@ public class AllowedManeuvers extends Asn1Bitstring {
           "reserved1"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LaneAttributes_Crosswalk.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LaneAttributes_Crosswalk.java
@@ -114,5 +114,4 @@ public class LaneAttributes_Crosswalk extends Asn1Bitstring {
           "unsignalizedSegmentsPresent"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LaneAttributes_Parking.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LaneAttributes_Parking.java
@@ -96,5 +96,4 @@ public class LaneAttributes_Parking extends Asn1Bitstring {
           "noPublicParkingUse"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LaneAttributes_Striping.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LaneAttributes_Striping.java
@@ -88,5 +88,4 @@ public class LaneAttributes_Striping extends Asn1Bitstring {
           "stripeToConnectingLanesAhead"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LaneAttributes_TrackedVehicle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LaneAttributes_TrackedVehicle.java
@@ -78,5 +78,4 @@ public class LaneAttributes_TrackedVehicle extends Asn1Bitstring {
           "spec-otherRailType"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LaneAttributes_Vehicle.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/MapData/LaneAttributes_Vehicle.java
@@ -105,5 +105,4 @@ public class LaneAttributes_Vehicle extends Asn1Bitstring {
           "permissionOnRequest"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/PersonalSafetyMessage/PersonalCrossingInProgress.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/PersonalSafetyMessage/PersonalCrossingInProgress.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.PersonalSafetyMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class PersonalCrossingInProgress extends Asn1Boolean {
-}
+public class PersonalCrossingInProgress extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/PersonalSafetyMessage/PersonalCrossingRequest.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/PersonalSafetyMessage/PersonalCrossingRequest.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.PersonalSafetyMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class PersonalCrossingRequest extends Asn1Boolean {
-}
+public class PersonalCrossingRequest extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/PersonalSafetyMessage/PersonalDeviceUsageState.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/PersonalSafetyMessage/PersonalDeviceUsageState.java
@@ -114,5 +114,4 @@ public class PersonalDeviceUsageState extends Asn1Bitstring {
           "viewing"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/Activity.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/Activity.java
@@ -24,5 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.RoadSafetyMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-public class Activity extends Asn1Boolean {
-}
+public class Activity extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/LaneClosed.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/RoadSafetyMessage/LaneClosed.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.RoadSafetyMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class LaneClosed extends Asn1Boolean {
-}
+public class LaneClosed extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/PedestrianBicycleDetect.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/PedestrianBicycleDetect.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.SPAT;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class PedestrianBicycleDetect extends Asn1Boolean {
-}
+public class PedestrianBicycleDetect extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/WaitOnStopline.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/SPAT/WaitOnStopline.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.SPAT;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class WaitOnStopline extends Asn1Boolean {
-}
+public class WaitOnStopline extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/ActuatedInterval.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/ActuatedInterval.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.TrafficLightStatusMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class ActuatedInterval extends Asn1Boolean {
-}
+public class ActuatedInterval extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/PedestrianCall.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/PedestrianCall.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.TrafficLightStatusMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class PedestrianCall extends Asn1Boolean {
-}
+public class PedestrianCall extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/ReservedBit.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/ReservedBit.java
@@ -24,6 +24,4 @@ package us.dot.its.jpo.asn.j2735.r2024.TrafficLightStatusMessage;
 
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
-
-public class ReservedBit extends Asn1Boolean {
-}
+public class ReservedBit extends Asn1Boolean {}

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/TrafficLightControllerStatus.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/TrafficLightControllerStatus.java
@@ -105,5 +105,4 @@ public class TrafficLightControllerStatus extends Asn1Bitstring {
           "reserved5"
         });
   }
-
 }

--- a/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/TrafficLightOperationStatus.java
+++ b/jpo-asn-j2735-2024/src/main/java/us/dot/its/jpo/asn/j2735/r2024/TrafficLightStatusMessage/TrafficLightOperationStatus.java
@@ -105,5 +105,4 @@ public class TrafficLightOperationStatus extends Asn1Bitstring {
           "reserved"
         });
   }
-
 }

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/BitstringGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/BitstringGenerator.java
@@ -1,8 +1,7 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import us.dot.its.jpo.asn.runtime.types.Asn1Bitstring;
-
 import java.util.Random;
+import us.dot.its.jpo.asn.runtime.types.Asn1Bitstring;
 
 public class BitstringGenerator extends RandomGenerator<Asn1Bitstring> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/BitstringGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/BitstringGenerator.java
@@ -1,7 +1,8 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.Random;
 import us.dot.its.jpo.asn.runtime.types.Asn1Bitstring;
+
+import java.util.Random;
 
 public class BitstringGenerator extends RandomGenerator<Asn1Bitstring> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/BooleanGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/BooleanGenerator.java
@@ -1,7 +1,8 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.Random;
 import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
+
+import java.util.Random;
 
 public class BooleanGenerator extends RandomGenerator<Asn1Boolean> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/BooleanGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/BooleanGenerator.java
@@ -1,8 +1,7 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
-
 import java.util.Random;
+import us.dot.its.jpo.asn.runtime.types.Asn1Boolean;
 
 public class BooleanGenerator extends RandomGenerator<Asn1Boolean> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ChoiceGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ChoiceGenerator.java
@@ -1,13 +1,12 @@
 package us.dot.its.jpo.asn.testgenerator;
 
+import java.util.List;
+import java.util.Random;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 import us.dot.its.jpo.asn.runtime.types.Asn1Choice;
 import us.dot.its.jpo.asn.runtime.types.Asn1Field;
 import us.dot.its.jpo.asn.runtime.types.Asn1Type;
-
-import java.util.List;
-import java.util.Random;
 
 public class ChoiceGenerator extends RandomGenerator<Asn1Choice> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ChoiceGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ChoiceGenerator.java
@@ -1,12 +1,13 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.List;
-import java.util.Random;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 import us.dot.its.jpo.asn.runtime.types.Asn1Choice;
 import us.dot.its.jpo.asn.runtime.types.Asn1Field;
 import us.dot.its.jpo.asn.runtime.types.Asn1Type;
+
+import java.util.List;
+import java.util.Random;
 
 public class ChoiceGenerator extends RandomGenerator<Asn1Choice> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/EnumeratedGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/EnumeratedGenerator.java
@@ -1,7 +1,8 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.Random;
 import us.dot.its.jpo.asn.runtime.types.Asn1Enumerated;
+
+import java.util.Random;
 
 public class EnumeratedGenerator extends RandomGenerator<Asn1Enumerated> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/EnumeratedGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/EnumeratedGenerator.java
@@ -1,8 +1,7 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import us.dot.its.jpo.asn.runtime.types.Asn1Enumerated;
-
 import java.util.Random;
+import us.dot.its.jpo.asn.runtime.types.Asn1Enumerated;
 
 public class EnumeratedGenerator extends RandomGenerator<Asn1Enumerated> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/IA5StringGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/IA5StringGenerator.java
@@ -1,8 +1,7 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import us.dot.its.jpo.asn.runtime.types.IA5String;
-
 import java.util.Random;
+import us.dot.its.jpo.asn.runtime.types.IA5String;
 
 public class IA5StringGenerator extends RandomGenerator<IA5String> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/IA5StringGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/IA5StringGenerator.java
@@ -1,7 +1,8 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.Random;
 import us.dot.its.jpo.asn.runtime.types.IA5String;
+
+import java.util.Random;
 
 public class IA5StringGenerator extends RandomGenerator<IA5String> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/IntegerGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/IntegerGenerator.java
@@ -1,8 +1,7 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import us.dot.its.jpo.asn.runtime.types.Asn1Integer;
-
 import java.util.Random;
+import us.dot.its.jpo.asn.runtime.types.Asn1Integer;
 
 public class IntegerGenerator extends RandomGenerator<Asn1Integer> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/IntegerGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/IntegerGenerator.java
@@ -1,7 +1,8 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.Random;
 import us.dot.its.jpo.asn.runtime.types.Asn1Integer;
+
+import java.util.Random;
 
 public class IntegerGenerator extends RandomGenerator<Asn1Integer> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ObjectIdentifierGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ObjectIdentifierGenerator.java
@@ -1,7 +1,8 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.Random;
 import us.dot.its.jpo.asn.runtime.types.Asn1ObjectIdentifier;
+
+import java.util.Random;
 
 public class ObjectIdentifierGenerator extends RandomGenerator<Asn1ObjectIdentifier> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ObjectIdentifierGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ObjectIdentifierGenerator.java
@@ -1,8 +1,7 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import us.dot.its.jpo.asn.runtime.types.Asn1ObjectIdentifier;
-
 import java.util.Random;
+import us.dot.its.jpo.asn.runtime.types.Asn1ObjectIdentifier;
 
 public class ObjectIdentifierGenerator extends RandomGenerator<Asn1ObjectIdentifier> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/OctetStringGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/OctetStringGenerator.java
@@ -1,7 +1,8 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.Random;
 import us.dot.its.jpo.asn.runtime.types.Asn1OctetString;
+
+import java.util.Random;
 
 public class OctetStringGenerator extends RandomGenerator<Asn1OctetString> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/OctetStringGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/OctetStringGenerator.java
@@ -1,8 +1,7 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import us.dot.its.jpo.asn.runtime.types.Asn1OctetString;
-
 import java.util.Random;
+import us.dot.its.jpo.asn.runtime.types.Asn1OctetString;
 
 public class OctetStringGenerator extends RandomGenerator<Asn1OctetString> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ParameterizedTypeGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ParameterizedTypeGenerator.java
@@ -1,5 +1,11 @@
 package us.dot.its.jpo.asn.testgenerator;
 
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.PropertyUtils;
@@ -7,13 +13,6 @@ import us.dot.its.jpo.asn.runtime.annotations.Asn1ParameterizedTypes;
 import us.dot.its.jpo.asn.runtime.annotations.Asn1ParameterizedTypes.Type;
 import us.dot.its.jpo.asn.runtime.types.Asn1Sequence;
 import us.dot.its.jpo.asn.runtime.types.Asn1Type;
-
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
 
 @Slf4j
 public class ParameterizedTypeGenerator extends RandomGenerator<Asn1Sequence> {

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ParameterizedTypeGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/ParameterizedTypeGenerator.java
@@ -1,11 +1,5 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.PropertyUtils;
@@ -13,6 +7,13 @@ import us.dot.its.jpo.asn.runtime.annotations.Asn1ParameterizedTypes;
 import us.dot.its.jpo.asn.runtime.annotations.Asn1ParameterizedTypes.Type;
 import us.dot.its.jpo.asn.runtime.types.Asn1Sequence;
 import us.dot.its.jpo.asn.runtime.types.Asn1Type;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 
 @Slf4j
 public class ParameterizedTypeGenerator extends RandomGenerator<Asn1Sequence> {

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/RandomGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/RandomGenerator.java
@@ -3,13 +3,12 @@ package us.dot.its.jpo.asn.testgenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import picocli.CommandLine.Model.CommandSpec;
-import us.dot.its.jpo.asn.runtime.annotations.Asn1ParameterizedTypes;
-import us.dot.its.jpo.asn.runtime.types.*;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Set;
+import picocli.CommandLine.Model.CommandSpec;
+import us.dot.its.jpo.asn.runtime.annotations.Asn1ParameterizedTypes;
+import us.dot.its.jpo.asn.runtime.types.*;
 
 public abstract class RandomGenerator<T extends Asn1Type> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/RandomGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/RandomGenerator.java
@@ -3,12 +3,13 @@ package us.dot.its.jpo.asn.testgenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Set;
 import picocli.CommandLine.Model.CommandSpec;
 import us.dot.its.jpo.asn.runtime.annotations.Asn1ParameterizedTypes;
 import us.dot.its.jpo.asn.runtime.types.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Set;
 
 public abstract class RandomGenerator<T extends Asn1Type> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/RelativeOIDGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/RelativeOIDGenerator.java
@@ -1,8 +1,7 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import us.dot.its.jpo.asn.runtime.types.Asn1RelativeOID;
-
 import java.util.Random;
+import us.dot.its.jpo.asn.runtime.types.Asn1RelativeOID;
 
 public class RelativeOIDGenerator extends RandomGenerator<Asn1RelativeOID> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/RelativeOIDGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/RelativeOIDGenerator.java
@@ -1,7 +1,8 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.Random;
 import us.dot.its.jpo.asn.runtime.types.Asn1RelativeOID;
+
+import java.util.Random;
 
 public class RelativeOIDGenerator extends RandomGenerator<Asn1RelativeOID> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/SequenceGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/SequenceGenerator.java
@@ -1,11 +1,10 @@
 package us.dot.its.jpo.asn.testgenerator;
 
+import java.util.ArrayList;
+import java.util.List;
 import us.dot.its.jpo.asn.runtime.types.Asn1Field;
 import us.dot.its.jpo.asn.runtime.types.Asn1Sequence;
 import us.dot.its.jpo.asn.runtime.types.Asn1Type;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class SequenceGenerator extends RandomGenerator<Asn1Sequence> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/SequenceGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/SequenceGenerator.java
@@ -1,10 +1,11 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.ArrayList;
-import java.util.List;
 import us.dot.its.jpo.asn.runtime.types.Asn1Field;
 import us.dot.its.jpo.asn.runtime.types.Asn1Sequence;
 import us.dot.its.jpo.asn.runtime.types.Asn1Type;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class SequenceGenerator extends RandomGenerator<Asn1Sequence> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/SequenceOfGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/SequenceOfGenerator.java
@@ -1,8 +1,9 @@
 package us.dot.its.jpo.asn.testgenerator;
 
-import java.util.Random;
 import us.dot.its.jpo.asn.runtime.types.Asn1SequenceOf;
 import us.dot.its.jpo.asn.runtime.types.Asn1Type;
+
+import java.util.Random;
 
 public class SequenceOfGenerator extends RandomGenerator<Asn1SequenceOf<?>> {
 

--- a/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/SequenceOfGenerator.java
+++ b/jpo-asn-test-generator/src/main/java/us/dot/its/jpo/asn/testgenerator/SequenceOfGenerator.java
@@ -1,9 +1,8 @@
 package us.dot.its.jpo.asn.testgenerator;
 
+import java.util.Random;
 import us.dot.its.jpo.asn.runtime.types.Asn1SequenceOf;
 import us.dot.its.jpo.asn.runtime.types.Asn1Type;
-
-import java.util.Random;
 
 public class SequenceOfGenerator extends RandomGenerator<Asn1SequenceOf<?>> {
 


### PR DESCRIPTION
Just a few minor suggestions/cleanup items for the PR: https://github.com/CDOT-CV/jpo-asn-pojos/pull/26 (which looks excellent by the way) that were easier to create a PR for rather than try to use Github code suggestions:

* Removes the hardcoded example from the BitstringDeserializer (the unit tests using ExampleBitstring seem to work fine without it)
* Uses Jackson's "ValueInstantiationException" checked exception in the `construct` methods, which seems appropriate, instead of RuntimeExceptions.
* Adds the 'spotless' plugin to `build.gradle` to automatically apply the Google code format to the POJOs, to make their format and whitespace identical to the existing ones.  This also makes it easier to compare with the auto generated POJOs, which apply the same format.  (I tested regenerating them with the changes to the base classes, and there were no differences aside from formatting).  Test classes are excluded from spotless in this PR to avoid adding tons of irrelevant changes to this.
* The `jpo-asn-test-generator` project already used the spotless plugin, this PR re-applies it to the changed classes to normalize the order of imports etc.