### PR TITLE
Add the distributionManagement to the pom

### DIFF
--- a/jpo-asn-j2735-2024/pom.xml
+++ b/jpo-asn-j2735-2024/pom.xml
@@ -16,6 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
+    <github_organization>usdot-jpo-ode</github_organization>
   </properties>
 
   <dependencies>
@@ -129,5 +130,11 @@
     </plugins>
   </build>
 
-
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/${github_organization}/jpo-ode</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/jpo-asn-runtime/pom.xml
+++ b/jpo-asn-runtime/pom.xml
@@ -16,6 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
+    <github_organization>usdot-jpo-ode</github_organization>
   </properties>
 
   <dependencies>
@@ -113,5 +114,11 @@
     </plugins>
   </build>
 
-
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/${github_organization}/jpo-ode</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,9 @@
     <module>jpo-asn-runtime</module>
     <module>jpo-asn-j2735-2024</module>
   </modules>
+  <properties>
+    <github_organization>usdot-jpo-ode</github_organization>
+  </properties>
   <distributionManagement>
     <repository>
       <id>github</id>

--- a/pom.xml
+++ b/pom.xml
@@ -13,4 +13,11 @@
     <module>jpo-asn-runtime</module>
     <module>jpo-asn-j2735-2024</module>
   </modules>
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/${github_organization}/jpo-ode</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,21 @@
   <description>Composite POM for jpo-asn pojo projects</description>
   <version>1.0.0</version>
   <packaging>pom</packaging>
+
+  <properties>
+    <github_organization>usdot-jpo-ode</github_organization>
+  </properties>
+
   <modules>
     <module>jpo-asn-runtime</module>
     <module>jpo-asn-j2735-2024</module>
   </modules>
+
+<distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/${github_organization}/jpo-ode</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,14 +13,4 @@
     <module>jpo-asn-runtime</module>
     <module>jpo-asn-j2735-2024</module>
   </modules>
-  <properties>
-    <github_organization>usdot-jpo-ode</github_organization>
-  </properties>
-  <distributionManagement>
-    <repository>
-      <id>github</id>
-      <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/${github_organization}/jpo-ode</url>
-    </repository>
-  </distributionManagement>
 </project>


### PR DESCRIPTION
Adds the distributionManagement tag to the repository pom.xml to allow for the jpo-ode to push its Maven packages that utilize this repository's projects.