### PR TITLE
Fix serializing bitstrings with the custom serializer

### DIFF
--- a/jpo-asn-runtime/src/main/java/us/dot/its/jpo/asn/runtime/serialization/BitstringSerializer.java
+++ b/jpo-asn-runtime/src/main/java/us/dot/its/jpo/asn/runtime/serialization/BitstringSerializer.java
@@ -41,8 +41,11 @@ public class BitstringSerializer extends StdSerializer<Asn1Bitstring> {
         jsonGenerator.writeStartObject();
         for (int i = 0; i < asn1Bitstring.size(); i++) {
             String name = asn1Bitstring.name(i);
-            boolean isSet = asn1Bitstring.get(i);
-            jsonGenerator.writeBooleanField(name, isSet);
+            if (name != null) {
+                // We don't write unnamed bits for this format
+                boolean isSet = asn1Bitstring.get(i);
+                jsonGenerator.writeBooleanField(name, isSet);
+            }
         }
         jsonGenerator.writeEndObject();
     }

--- a/jpo-asn-runtime/src/main/java/us/dot/its/jpo/asn/runtime/types/Asn1Bitstring.java
+++ b/jpo-asn-runtime/src/main/java/us/dot/its/jpo/asn/runtime/types/Asn1Bitstring.java
@@ -233,11 +233,15 @@ public abstract class Asn1Bitstring implements Asn1Type {
     /**
      * Get the name representing the requested index.
      *
-     * @param index The index value of the bitstring being requested.
+     * @param index The index value of the bitstring being requested or null if no name exists.
      */
     public String name(int index) {
         if (index < 0 || index >= size()) {
             throw new IllegalArgumentException(String.format("Index %s out of range %s-%s", index, 0, size()));
+        }
+        if (names.length <= index) {
+            // Name does not exist
+            return null;
         }
         return names[index];
     }

--- a/jpo-asn-runtime/src/test/java/us/dot/its/jpo/asn/runtime/examples/ExampleBitstringFewNamedBits.java
+++ b/jpo-asn-runtime/src/test/java/us/dot/its/jpo/asn/runtime/examples/ExampleBitstringFewNamedBits.java
@@ -1,0 +1,52 @@
+package us.dot.its.jpo.asn.runtime.examples;
+
+import us.dot.its.jpo.asn.runtime.types.Asn1Bitstring;
+
+/**
+ * Example of a BITSTRING where the number of named bits is smaller
+ * than the size
+ */
+public class ExampleBitstringFewNamedBits extends Asn1Bitstring {
+
+  public boolean isSidewalk_RevocableLane() {
+    return get(0);
+  }
+
+  public void setSidewalk_RevocableLane(boolean sidewalk_RevocableLane) {
+    set(0, sidewalk_RevocableLane);
+  }
+
+  public boolean isBicyleUseAllowed() {
+    return get(1);
+  }
+
+  public void setBicyleUseAllowed(boolean bicyleUseAllowed) {
+    set(1, bicyleUseAllowed);
+  }
+
+  public boolean isIsSidewalkFlyOverLane() {
+    return get(2);
+  }
+
+  public void setIsSidewalkFlyOverLane(boolean isSidewalkFlyOverLane) {
+    set(2, isSidewalkFlyOverLane);
+  }
+
+  public boolean isWalkBikes() {
+    return get(3);
+  }
+
+  public void setWalkBikes(boolean walkBikes) {
+    set(3, walkBikes);
+  }
+
+  public ExampleBitstringFewNamedBits() {
+    super(
+        16,
+        false,
+        new String[] {
+            "sidewalk-RevocableLane", "bicyleUseAllowed", "isSidewalkFlyOverLane", "walkBikes"
+        });
+  }
+
+}

--- a/jpo-asn-runtime/src/test/java/us/dot/its/jpo/asn/runtime/serialization/OdeCustomJsonMapperTest.java
+++ b/jpo-asn-runtime/src/test/java/us/dot/its/jpo/asn/runtime/serialization/OdeCustomJsonMapperTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import us.dot.its.jpo.asn.runtime.examples.ExampleBitstring;
+import us.dot.its.jpo.asn.runtime.examples.ExampleBitstringFewNamedBits;
 
 public class OdeCustomJsonMapperTest {
 
@@ -48,11 +49,51 @@ public class OdeCustomJsonMapperTest {
     assertThat(ebs.hexString(), equalToIgnoringCase(HEX_STRING));
   }
 
+  @Test
+  public void serializeHumanReadable_FewNamedBits() throws JsonProcessingException {
+    var mapper = new OdeCustomJsonMapper(true);
+    var ebs = new ExampleBitstringFewNamedBits();
+    ebs.fromBinaryString(BINARY_STRING_FEW_NAMED_BITS);
+    final String str = mapper.writeValueAsString(ebs);
+    assertThat(str, jsonEquals(HUMAN_READABLE_JSON_FEW_NAMED_BITS));
+  }
+
+  @Test
+  public void deserializeHumanReadable_FewNamedBits() throws JsonProcessingException {
+    var mapper = new OdeCustomJsonMapper(true);
+    var ebs = mapper.readValue(HUMAN_READABLE_JSON_FEW_NAMED_BITS, ExampleBitstringFewNamedBits.class);
+    assertThat(ebs, notNullValue());
+    assertThat(ebs.binaryString(), equalTo(BINARY_STRING_FEW_NAMED_BITS));
+    assertThat(ebs.hexString(), equalToIgnoringCase(HEX_STRING_FEW_NAMED_BITS));
+  }
+
+  @Test
+  public void serializeHex_FewNamedBits() throws JsonProcessingException {
+    var mapper = new OdeCustomJsonMapper(false);
+    var ebs = new ExampleBitstringFewNamedBits();
+    ebs.fromBinaryString(BINARY_STRING_FEW_NAMED_BITS);
+    final String str = mapper.writeValueAsString(ebs);
+    assertThat(str, equalToIgnoringCase(HEX_JSON_FEW_NAMED_BITS));
+  }
+
+  @Test
+  public void deserializeHex_FewNamedBits() throws JsonProcessingException {
+    var mapper = new OdeCustomJsonMapper(false);
+    var ebs = mapper.readValue(HEX_JSON_FEW_NAMED_BITS, ExampleBitstringFewNamedBits.class);
+    assertThat(ebs, notNullValue());
+    assertThat(ebs.binaryString(), equalTo(BINARY_STRING_FEW_NAMED_BITS));
+    assertThat(ebs.hexString(), equalToIgnoringCase(HEX_STRING_FEW_NAMED_BITS));
+  }
+
   static final String BINARY_STRING = "1111111111111111";
+  static final String BINARY_STRING_FEW_NAMED_BITS = "1111000000000000";
+
 
   static final String HEX_STRING = "FFFF";
+  static final String HEX_STRING_FEW_NAMED_BITS = "F000";
 
   static final String HEX_JSON = "\"" + HEX_STRING + "\"";
+  static final String HEX_JSON_FEW_NAMED_BITS = "\"" + HEX_STRING_FEW_NAMED_BITS + "\"";
 
   static final String HUMAN_READABLE_JSON = """
       {
@@ -74,5 +115,16 @@ public class OdeCustomJsonMapperTest {
           "from337-5to360-0degrees": true
       }
       """;
+
+  static final String HUMAN_READABLE_JSON_FEW_NAMED_BITS = """
+      {
+        "sidewalk-RevocableLane": true,
+        "bicyleUseAllowed": true,
+        "isSidewalkFlyOverLane": true,
+        "walkBikes": true
+      }
+      """;
+
+
 
 }


### PR DESCRIPTION
Fixes an issue that caused an exception when using the OdeCustomJsonMapper to serialize bitstrings where the number of named bits is smaller than the size.

Adds unit tests for this case.